### PR TITLE
Fix NumberFormatException on long running tests

### DIFF
--- a/src/main/java/hudson/plugins/performance/JUnitParser.java
+++ b/src/main/java/hudson/plugins/performance/JUnitParser.java
@@ -93,8 +93,7 @@ public class JUnitParser extends JMeterParser {
               currentSample = new HttpSample();
               currentSample.setDate(new Date(0));
               String time = attributes.getValue("time");
-              double duration = Double.parseDouble(time);
-              currentSample.setDuration((long) (duration * 1000));
+              currentSample.setDuration(parseDuration(time));
               currentSample.setSuccessful(true);
               currentSample.setUri(attributes.getValue("name"));
             } else if ("failure".equalsIgnoreCase(qName) && status != 0) {
@@ -114,5 +113,13 @@ public class JUnitParser extends JMeterParser {
     }
 
     return result;
+  }
+  
+  /**
+   * Strips any commas from <code>time</code>, then parses it into a long.
+   */
+  long parseDuration(final String time) {
+    double duration = Double.parseDouble(time.replaceAll(",", "")); //don't want commas or else will break on parse
+    return (long) (duration * 1000);
   }
 }

--- a/src/test/java/hudson/plugins/performance/JUnitParserTest.java
+++ b/src/test/java/hudson/plugins/performance/JUnitParserTest.java
@@ -1,0 +1,22 @@
+package hudson.plugins.performance;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class JUnitParserTest {
+
+	/**
+	 * Test parsing a test with a long duration (ie. over 999 seconds) will work.
+	 * Previously this was causing a NumberFormatException since it puts commas
+	 * in for over 999 seconds, causing system to complain.
+	 */
+	@Test
+	public void testParseDurationLongRunningTest() {
+		JUnitParser parser = new JUnitParser(null);
+		assertEquals("Test having a time with commas will work.", parser.parseDuration("34,953.254"), (long) 34953254);
+		assertEquals("Test having a time with multiple commas will work.", parser.parseDuration("1,134,953.254"), (long) 1134953254);
+		assertEquals("Test that time with no commas still work.", parser.parseDuration("999.999"), (long) 999999);
+	}
+
+}


### PR DESCRIPTION
When the parser tries to parse a long running test (over 999 seconds), the plugin throws a NFE when a user tries to view the results of the test run in graph format. 

An example of failure:

java.lang.NumberFormatException: For input string: "34,953.254"
    at sun.misc.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:1242)
    at java.lang.Double.parseDouble(Double.java:527)
    at hudson.plugins.performance.JUnitParser$1.startElement(JUnitParser.java:96)

It now strips out any commas before trying to parse the String. Added test as well.
