### PR TITLE
fix JENKINS-14146

### DIFF
--- a/src/main/java/hudson/plugins/performance/GraphConfigurationDetail.java
+++ b/src/main/java/hudson/plugins/performance/GraphConfigurationDetail.java
@@ -36,7 +36,8 @@ public class GraphConfigurationDetail implements ModelObject {
   /** Logger. */
   private static final Logger LOGGER = Logger.getLogger(GraphConfigurationDetail.class.getName());
 
-  public static final String SEPARATOR = ";";
+  public static final String LEGACY_SEPARATOR = ";";
+  public static final String SEPARATOR = ":";
   /** The number of builds to consider. */
   private int buildCount;
   /** The first days to consider. */
@@ -206,7 +207,12 @@ public class GraphConfigurationDetail implements ModelObject {
       return listErrors;
     }
 
-    String[] values = StringUtils.split(value, SEPARATOR);
+    String[] values;
+    if (value.contains(LEGACY_SEPARATOR))
+        values = StringUtils.split(value, LEGACY_SEPARATOR);
+    else
+        values = StringUtils.split(value, SEPARATOR);
+
     if (values.length != 4) {
       listErrors.add(-1);
       return listErrors;


### PR DESCRIPTION
";" separator for values in cookie breaks the HTTP Cookie header, as same ";" separator is used to distinguish multiple cookies (typically, JSESSIONID for security filters)
