### PR TITLE
Fixed commas inside quoted text

### DIFF
--- a/src/main/java/hudson/plugins/performance/JMeterCsvParser.java
+++ b/src/main/java/hudson/plugins/performance/JMeterCsvParser.java
@@ -147,7 +147,8 @@ public class JMeterCsvParser extends PerformanceReportParser {
      */
     private HttpSample getSample(String line) {
         HttpSample sample = new HttpSample();
-        String[] values = line.split(delimiter);
+        final String commasNotInsideQuotes = ",(?=([^\"]*\"[^\"]*\")*[^\"]*$)";
+        String[] values = line.split(commasNotInsideQuotes);
         sample.setDate(new Date(Long.valueOf(values[timestampIdx])));
         sample.setDuration(Long.valueOf(values[elapsedIdx]));
         sample.setHttpCode(values[responseCodeIdx]);


### PR DESCRIPTION
The CSV parser changes from last committer did not take into account that commas can be inside quoted strings.
