### PR TITLE
Storing parsed JMeter report results into xml file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,11 @@
       <artifactId>jna</artifactId>
       <version>3.2.2</version>
     </dependency>
+      <dependency>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+          <version>11.0.1</version>
+      </dependency>
   </dependencies>
 
   <distributionManagement>


### PR DESCRIPTION
After parsing the JMeter reports, the results are stored into a xml file that is stored as an artifact of the build.
- For the error threshold calculation, the xml file contains response times information.
- For the build comparison, the xml file contains the comparison results between two builds and response times information. (comparison works for single jmeter files)

Location of xml file : Archive folder for every build
