### PR TITLE
Fixing xml file creation bugs

### DIFF
--- a/src/main/java/hudson/plugins/performance/PerformancePublisher.java
+++ b/src/main/java/hudson/plugins/performance/PerformancePublisher.java
@@ -354,7 +354,7 @@ public class PerformancePublisher extends Recorder {
             FileWriter fw = new FileWriter(xmlfile.getAbsoluteFile());
             BufferedWriter bw = new BufferedWriter(fw);
 
-            xml += "<?xml version=\"1.0\"?>\n";
+            xml = "<?xml version=\"1.0\"?>\n";
             xml += "<results>\n";
             xml += "<absoluteDefinition>\n";
 
@@ -532,6 +532,7 @@ public class PerformancePublisher extends Recorder {
             r.setBuildAction(a);
             // URI list is the list of labels in the current JMeter results file
             curruriList = r.getUriListOrdered();
+            break;
           }
         }
 
@@ -589,6 +590,7 @@ public class PerformancePublisher extends Recorder {
 
               //uri list is the list of labels in the previous jmeter results file
               prevuriList = r.getUriListOrdered();
+              break;
             }
           }
 
@@ -746,8 +748,6 @@ public class PerformancePublisher extends Recorder {
 
           inside += avg + med + perct;
           bw.write(inside+"\n");
-
-
 
         }
         bw.write("</results>");


### PR DESCRIPTION
1. Summary xml file would be created in case the previous build is null for relative comparison.
2. For Error % comparison, fixed multiple file creation for multiple Jmeter result files.
