### PR TITLE
Fix issue with not pulling in saved config to job

### DIFF
--- a/src/main/java/hudson/plugins/performance/IagoParser.java
+++ b/src/main/java/hudson/plugins/performance/IagoParser.java
@@ -35,10 +35,10 @@ import javax.xml.bind.ValidationException;
  */
 public class IagoParser extends PerformanceReportParser {
   
-  private String statsDateFormat;
-  private String delimiter;
-  private String pattern;
-  private String[] patterns;	
+  public String statsDateFormat;
+  public String delimiter;
+  public String pattern;
+  public String[] patterns;	
   
   @Extension
   public static class DescriptorImpl extends PerformanceReportParserDescriptor {


### PR DESCRIPTION
Requires public accessible class variables for setting saved Jenkins config
