### PR TITLE
Sort performance report by URI. Fixes #23158

### DIFF
--- a/src/main/java/hudson/plugins/performance/PerformanceReport.java
+++ b/src/main/java/hudson/plugins/performance/PerformanceReport.java
@@ -191,8 +191,9 @@ public class PerformanceReport extends AbstractReport implements Serializable,
 
   public List<UriReport> getUriListOrdered() {
     Collection<UriReport> uriCollection = getUriReportMap().values();
-    List<UriReport> UriReportList = new ArrayList<UriReport>(uriCollection);
-    return UriReportList;
+    List<UriReport> uriReportList = new ArrayList<UriReport>(uriCollection);
+    Collections.sort(uriReportList, Collections.reverseOrder());
+    return uriReportList;
   }
 
   public Map<String, UriReport> getUriReportMap() {

--- a/src/test/java/hudson/plugins/performance/PerformanceReportTest.java
+++ b/src/test/java/hudson/plugins/performance/PerformanceReportTest.java
@@ -191,4 +191,11 @@ public class PerformanceReportTest {
 		UriReport report = uriReportMap.get("Home");
 		assertNotNull(report);
 	}
+
+    @Test
+    public void testGetUriListOrdered() throws IOException, SAXException {
+        PerformanceReport performanceReport = parseOneJMeter(new File("src/test/resources/JMeterResultsRandomUri.jtl"));
+        List<UriReport> uriReports = performanceReport.getUriListOrdered();
+        assertEquals("Ant", uriReports.get(0).getUri());
+    }
 }

--- a/src/test/resources/JMeterResultsRandomUri.jtl
+++ b/src/test/resources/JMeterResultsRandomUri.jtl
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testResults version="1.2">
+<httpSample t="14720" lt="9770" ts="1296846793179" s="true" lb="Bat" rc="200" rm="OK" tn="Sesiones de usuario 1-2" dt="text" by="771065"/>
+<httpSample t="278" lt="148" ts="1296846847952" s="true" lb="Dog" rc="200" rm="OK" tn="Sesiones de usuario 1-2" dt="text" by="744705"/>
+<httpSample t="598" lt="321" ts="1296846947037" s="true" lb="Ant" rc="200" rm="OK" tn="Sesiones de usuario 1-1" dt="text" by="771149"/>
+<httpSample t="63" lt="3" ts="1296846968923" s="true" lb="Cat" rc="200" rm="OK" tn="Sesiones de usuario 1-1" dt="text" by="744705"/>
+</testResults>


### PR DESCRIPTION
Fixes #23158

This is a simple fix that lists the performance reports table ordered by URI in alphabetical order. Implementation is similar to what was suggested in issue 23158.

Unit test is also included to test the ordered list, which required a new results file, JMeterResultsRandomUri.jtl. This files data is similar to what is in JMeterResults.jtl but with changes to the lb field as needed for the test.

All unit tests passed. Also tested it manually by running Jenkins locally with: mvn hpi:run and verifying in browser.
