### PR TITLE
fixes-27350

### DIFF
--- a/src/main/java/hudson/plugins/performance/PerformanceReport.java
+++ b/src/main/java/hudson/plugins/performance/PerformanceReport.java
@@ -98,7 +98,7 @@ public class PerformanceReport extends AbstractReport implements Serializable,
     synchronized (uriReportMap) {
       UriReport uriReport = uriReportMap.get(staplerUri);
       if (uriReport == null) {
-        uriReport = new UriReport(staplerUri, uri);
+        uriReport = new UriReport(this, staplerUri, uri);
         uriReportMap.put(staplerUri, uriReport);
       }
       uriReport.addHttpSample(pHttpSample);

--- a/src/main/resources/hudson/plugins/performance/UriReport/index.jelly
+++ b/src/main/resources/hudson/plugins/performance/UriReport/index.jelly
@@ -27,13 +27,11 @@
       <table class="sortable source" border="1">
         <j:choose>
           <j:when test="${it.getPerformanceReport().ifSummarizerParserUsed(it.getPerformanceReport().getReportFileName())}">
-            <th>${%URI}</th>
             <th>${%Samples}</th>
             <th>${%Time}</th>
             <th>${% Avg Response Time} (ms)</th>
             <j:forEach var="c" items="${it.httpSampleList}">
                 <tr>
-                <td class="left">${c.uri}</td>
                 <td>${c.summarizerSamples}</td>
                 <td class="center">${c.date}</td>
                 <td>${c.duration} ms.</td>
@@ -41,13 +39,11 @@
             </j:forEach>
           </j:when>
           <j:otherwise>
-            <th>${%URI}</th>
             <th>${%Http Code}</th>
             <th>${%Time}</th>
             <th>${%Duration} (ms)</th>
             <j:forEach var="c" items="${it.httpSampleList}">
                 <tr class="${h.ifThenElse(c.failed,'red','')}">
-                <td class="left">${c.uri}</td>
                 <td>${c.httpCode}</td>
                 <td class="center">${c.date}</td>
                 <td>${c.duration} ms.</td>

--- a/src/test/java/hudson/plugins/performance/ThroughputReportTest.java
+++ b/src/test/java/hudson/plugins/performance/ThroughputReportTest.java
@@ -24,13 +24,13 @@ public class ThroughputReportTest {
         HttpSample httpSample1 = new HttpSample();
         httpSample1.setDate(new Date());
 
-        UriReport uriReport1 = new UriReport("f", "url1");
+        UriReport uriReport1 = new UriReport(performanceReport, "f", "url1");
         uriReport1.addHttpSample(httpSample1);
 
         HttpSample httpSample2 = new HttpSample();
         httpSample2.setDate(new Date());
 
-        UriReport uriReport2 = new UriReport("f", "url2");
+        UriReport uriReport2 = new UriReport(performanceReport, "f", "url2");
         uriReport2.addHttpSample(httpSample2);
 
         performanceReport.getUriReportMap().put(uriReport1.getUri(), uriReport1);

--- a/src/test/java/hudson/plugins/performance/ThroughputUriReportTest.java
+++ b/src/test/java/hudson/plugins/performance/ThroughputUriReportTest.java
@@ -10,7 +10,8 @@ import java.util.Date;
  */
 public class ThroughputUriReportTest {
 
-    private UriReport uriReport = new UriReport("f", "x");
+    private PerformanceReport performanceReport = new PerformanceReport();
+    private UriReport uriReport = new UriReport(performanceReport, "f", "x");
 
     private ThroughputUriReport throughputUriReport = new ThroughputUriReport(uriReport);
 

--- a/src/test/java/hudson/plugins/performance/UriReportTest.java
+++ b/src/test/java/hudson/plugins/performance/UriReportTest.java
@@ -16,14 +16,15 @@ import org.junit.Test;
 
 public class UriReportTest {
 
-	private static final long AVERAGE = 5;
+    private static final String HTTP_200 = "200";
+    private static final long AVERAGE = 5;
 	private static final long MIN = 0;
 	private static final long MAX = 10;
 	private UriReport uriReport;
 
 	@Before
 	public void setUp() {
-		uriReport = new UriReport(null, null);
+		uriReport = new UriReport(null, null, null);
 		HttpSample httpSample1 = new HttpSample();
 		httpSample1.setDuration(MAX);
 		Date date = new Date();
@@ -74,8 +75,8 @@ public class UriReportTest {
 	public void testCompareSameDateDifferentDuration() {
 	  // setup fixture
     final List<Sample> samples = new ArrayList<Sample>();
-	  samples.add( new Sample( new Date(1), 2) );
-    samples.add( new Sample( new Date(1), 1) );
+	  samples.add( new Sample(HTTP_200, new Date(1), 2) );
+    samples.add( new Sample(HTTP_200, new Date(1), 1) );
     
 	  // execute system under test
     Collections.sort(samples);
@@ -93,8 +94,8 @@ public class UriReportTest {
   public void testCompareDifferentDateSameDuration() {
     // setup fixture
     final List<Sample> samples = new ArrayList<Sample>();
-    samples.add( new Sample( new Date(2), 1) );
-    samples.add( new Sample( new Date(1), 1) );
+    samples.add( new Sample(HTTP_200, new Date(2), 1) );
+    samples.add( new Sample(HTTP_200, new Date(1), 1) );
     
     // execute system under test
     Collections.sort(samples);
@@ -112,8 +113,8 @@ public class UriReportTest {
   public void testCompareDifferentDateDifferentDuration() {
     // setup fixture
     final List<Sample> samples = new ArrayList<Sample>();
-    samples.add( new Sample( new Date(1), 2) );
-    samples.add( new Sample( new Date(2), 1) );
+    samples.add( new Sample(HTTP_200, new Date(1), 2) );
+    samples.add( new Sample(HTTP_200, new Date(2), 1) );
     
     // execute system under test
     Collections.sort(samples);
@@ -131,8 +132,8 @@ public class UriReportTest {
   public void testCompareNullDateSameDuration() {
     // setup fixture
     final List<Sample> samples = new ArrayList<Sample>();
-    samples.add( new Sample( null, 1) );
-    samples.add( new Sample( null, 1) );
+    samples.add( new Sample(HTTP_200, null, 1) );
+    samples.add( new Sample(HTTP_200, null, 1) );
     
     try {
       // execute system under test


### PR DESCRIPTION
Add shorturi method back to UriReport. This method is used in Jelly script which displays the uri used for test.

Removed sample values need to be added back for the uriReport page.
URI column is redundant on the uriReport page.