### PR TITLE
Add checkbox in job config in order to choose build status when result performance file are not present

### DIFF
--- a/src/main/java/hudson/plugins/performance/PerformancePublisher.java
+++ b/src/main/java/hudson/plugins/performance/PerformancePublisher.java
@@ -99,6 +99,8 @@ public class PerformancePublisher extends Recorder {
   private String configType="ART";
 
   private boolean modeOfThreshold = false;
+  
+  private boolean failBuildIfNoResultFile = false;
 
   private boolean compareBuildPrevious = false;
 
@@ -145,6 +147,7 @@ public class PerformancePublisher extends Recorder {
                             boolean modePerformancePerTestCase,
                             String comparisonType,
                             boolean modeOfThreshold,
+                            boolean failBuildIfNoResultFile,
                             boolean compareBuildPrevious,
                             List<? extends PerformanceReportParser> parsers,
                             boolean modeThroughput) {
@@ -162,6 +165,7 @@ public class PerformancePublisher extends Recorder {
     this.configType = comparisonType;
     PerformancePublisher.optionType = comparisonType;
     this.modeOfThreshold = modeOfThreshold;
+    this.failBuildIfNoResultFile = failBuildIfNoResultFile;
     this.compareBuildPrevious = compareBuildPrevious;
 
     if (parsers == null)
@@ -336,7 +340,9 @@ public class PerformancePublisher extends Recorder {
             if (build.getResult().isWorseThan(Result.UNSTABLE)) {
               return true;
             }
-            build.setResult(Result.FAILURE);
+            if (failBuildIfNoResultFile) {
+            	build.setResult(Result.FAILURE);
+            }
             logger.println("Performance: no " + parser.getReportName()
                     + " files matching '" + glob
                     + "' have been found. Has the report generated?. Setting Build to "
@@ -527,7 +533,9 @@ public class PerformancePublisher extends Recorder {
             if (build.getResult().isWorseThan(Result.UNSTABLE)) {
                 return true;
             }
-            build.setResult(Result.FAILURE);
+            if (failBuildIfNoResultFile) {
+            	build.setResult(Result.FAILURE);
+            }
             logger.println("Performance: no " + parser.getReportName()
                     + " files matching '" + glob
                     + "' have been found. Has the report generated?. Setting Build to "

--- a/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.jelly
@@ -9,7 +9,13 @@
   <f:entry title="Select mode:   ">
     <f:booleanRadio name="modeOfThreshold" field="modeOfThreshold" true="Relative Threshold" false="Error Threshold" />
   </f:entry>
-
+ 
+   <f:entry title="Build result:   ">
+		<f:checkbox name="failBuildIfNoResultFile" title="Fail build when result files are not present" field="failBuildIfNoResultFile">
+		    		  Fail build when result files are not present
+        </f:checkbox>
+  </f:entry>
+  
   <f:block>
     <f:entry title="Use Error thresholds on single build:   ">
       <table width="500px">

--- a/src/test/java/hudson/plugins/performance/PerformancePublisherTest.java
+++ b/src/test/java/hudson/plugins/performance/PerformancePublisherTest.java
@@ -21,7 +21,7 @@ import static java.util.Arrays.asList;
  */
   public class PerformancePublisherTest extends HudsonTestCase{
     public void testConfigRoundtrip() throws Exception {
-        PerformancePublisher before = new PerformancePublisher(10, 20, "",0,0,0,0,0,false,"",false,false,
+        PerformancePublisher before = new PerformancePublisher(10, 20, "",0,0,0,0,0,false,"",false,false,false,
                 asList(new JMeterParser("**/*.jtl")),false);
 
         FreeStyleProject p = createFreeStyleProject();
@@ -58,7 +58,7 @@ import static java.util.Arrays.asList;
 			}
 		});
         p.getPublishersList().add(
-                new PerformancePublisher(0, 0, "", 0, 0, 0, 0, 0, false, "", false, false, asList(new JMeterParser(
+                new PerformancePublisher(0, 0, "", 0, 0, 0, 0, 0, false, "", false, false,false, asList(new JMeterParser(
                         "**/*.jtl")),false));
 
 		FreeStyleBuild b = assertBuildStatusSuccess(p.scheduleBuild2(0).get());
@@ -89,7 +89,7 @@ import static java.util.Arrays.asList;
 			}
 		});
         p.getPublishersList().add(
-                new PerformancePublisher(0, 0, "", 0, 0, 0, 0, 0, false, "", false, false, asList(new JMeterParser(
+                new PerformancePublisher(0, 0, "", 0, 0, 0, 0, 0, false, "", false, false, false, asList(new JMeterParser(
                         "${JOB_NAME}/*.jtl")),false));
 
 		FreeStyleBuild b = assertBuildStatusSuccess(p.scheduleBuild2(0).get());
@@ -121,7 +121,7 @@ import static java.util.Arrays.asList;
             }
         });
         p.getPublishersList().add(
-                new PerformancePublisher(0, 0, "test.jtl:100", 0, 0, 0, 0, 0, false, "", false, false, asList(new JMeterParser(
+                new PerformancePublisher(0, 0, "test.jtl:100", 0, 0, 0, 0, 0, false, "", false, false, false, asList(new JMeterParser(
                         "**/*.jtl")),false));
 
         FreeStyleBuild b = assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0).get());
@@ -153,7 +153,7 @@ import static java.util.Arrays.asList;
             }
         });
         p.getPublishersList().add(
-                new PerformancePublisher(0, 0, "test.jtl:5000", 0, 0, 0, 0, 0, false, "", false, false, asList(new JMeterParser(
+                new PerformancePublisher(0, 0, "test.jtl:5000", 0, 0, 0, 0, 0, false, "", false, false, false, asList(new JMeterParser(
                         "**/*.jtl")),false));
 
         FreeStyleBuild b = assertBuildStatusSuccess(p.scheduleBuild2(0).get());
@@ -183,7 +183,7 @@ import static java.util.Arrays.asList;
         FreeStyleProject p = createFreeStyleProject();
 
         p.getPublishersList().add(
-                new PerformancePublisher(0, 0, null, 100.0d, 0, 50.0d, 0, 0, false, "ART", true, true, asList(new JUnitParser(
+                new PerformancePublisher(0, 0, null, 100.0d, 0, 50.0d, 0, 0, false, "ART", true, false,true, asList(new JUnitParser(
                         "**/*.xml")), false));
         // first build
         p.getBuildersList().add(new TestBuilder() {


### PR DESCRIPTION
Because it is possible to have for a same job different build options, build status should not be systematically failed if result files were not finded.
I added a checkbox option in job configuration page in order to manage build status for that need.