### PR TITLE
Compatible with flexible publisher

### DIFF
--- a/src/main/java/hudson/plugins/performance/PerformanceReport.java
+++ b/src/main/java/hudson/plugins/performance/PerformanceReport.java
@@ -298,24 +298,19 @@ public class PerformanceReport extends AbstractReport implements Serializable,
    * @return boolean indicating usage of summarized parser
    */
   public boolean ifSummarizerParserUsed(String filename) {
-    List<PerformanceReportParser> list = buildAction.getBuild().getProject()
-        .getPublishersList().get(PerformancePublisher.class).getParsers();
-
-    for (int i = 0; i < list.size(); i++) {
-      if (list.get(i).getDescriptor().getDisplayName()
-          .equals("JmeterSummarizer")) {
-        String fileExt = list.get(i).glob;
-        String parts[] = fileExt.split("\\s*[;:,]+\\s*");
-        for (String path : parts) {
-          if (filename.endsWith(path.substring(5))) {
-            return true;
-          }
+    PerformanceReportParser parser = buildAction.getParserByDisplayName("JmeterSummarizer");
+    if (parser != null) {
+      String fileExt = parser.glob;
+      String parts[] = fileExt.split("\\s*[;:,]+\\s*");
+      for (String path : parts) {
+        if (filename.endsWith(path.substring(5))) {
+         return true;
         }
-      } else if (list.get(i).getDescriptor().getDisplayName()
-        .equals("Iago")) {
-        return true;
       }
-      
+    }
+    parser = buildAction.getParserByDisplayName("Iago");
+    if (parser != null) {
+      return true;
     }
     return false;
   }


### PR DESCRIPTION
The original parser lookup in ifSummarizerParsedUsed is not comptaible with flexible publisher, because the performance publisher is not directly in buildAction.getBuild().getProject().getPublishersList(), but wrapped inside publisher list of flexible publisher. It will result in NPE because buildAction.getBuild().getProject().getPublishersList().get(PerformancePublisher.class) return null.

We can just simply look up with buildAction.getParserByDisplayName directly instead of looping the project publisher list to check for JmeterSummarizer and Iago parser. The parser list is already there in buildAction. This way the code is simpler, and we can avoid complicated lookup when this publisher is under flexible publisher.