### PR TITLE
JENKINS-27350: Fix for uri column value not shown as link

### DIFF
--- a/src/main/resources/hudson/plugins/performance/PerformanceReportMap/index.jelly
+++ b/src/main/resources/hudson/plugins/performance/PerformanceReportMap/index.jelly
@@ -19,7 +19,9 @@
          <j:forEach var="uriReport" items="${performanceReport.getUriListOrdered()}">
            <tr class="${h.ifThenElse(uriReport.failed,'red','')}">
              <td class="left">
-               <st:out value="${uriReport.getStaplerUri()}" />
+               <a href="./uriReport/${uriReport.encodeUriReport()}">
+                 <st:out value="${uriReport.getStaplerUri()}" />
+               </a>
              </td>
            <j:choose>
              <j:when test="${performanceReport.ifSummarizerParserUsed(performanceReport.getReportFileName())}">


### PR DESCRIPTION
Re-add link to uri report, on the performance report page.
https://issues.jenkins-ci.org/browse/JENKINS-27350