### PR TITLE
JENKINS-10642: Sort correctly on date values

### DIFF
--- a/src/main/resources/hudson/plugins/performance/UriReport/index.jelly
+++ b/src/main/resources/hudson/plugins/performance/UriReport/index.jelly
@@ -33,7 +33,7 @@
             <j:forEach var="c" items="${it.httpSampleList}">
                 <tr>
                 <td>${c.summarizerSamples}</td>
-                <td class="center">${c.date}</td>
+                <td class="center" data="${c.date.getTime()}">${c.date}</td>
                 <td>${c.duration} ms.</td>
                 </tr>
             </j:forEach>
@@ -45,7 +45,7 @@
             <j:forEach var="c" items="${it.httpSampleList}">
                 <tr class="${h.ifThenElse(c.failed,'red','')}">
                 <td>${c.httpCode}</td>
-                <td class="center">${c.date}</td>
+                <td class="center" data="${c.date.getTime()}">${c.date}</td>
                 <td>${c.duration} ms.</td>
                 </tr>
             </j:forEach>


### PR DESCRIPTION
Created copy of test/resources/JMeterResults.jtl test file. Added additional data values with timestamps as specified in issue JENKINS-10642.

Manually tested sorting using a copy of JMeterResults.jtl file as the data source in Jenkins.