### PR TITLE
Use 0 for time when no value is provided in Junit test result

### DIFF
--- a/src/main/java/hudson/plugins/performance/JUnitParser.java
+++ b/src/main/java/hudson/plugins/performance/JUnitParser.java
@@ -1,6 +1,7 @@
 package hudson.plugins.performance;
 
 import hudson.Extension;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
@@ -96,8 +97,12 @@ public class JUnitParser extends AbstractParser {
    * Strips any commas from <code>time</code>, then parses it into a long.
    */
   static long parseDuration(final String time) {
-    // don't want commas or else will break on parse.
-    final double duration = Double.parseDouble(time.replaceAll(",", ""));
-    return (long) (duration * 1000);
+    if(StringUtils.isEmpty(time)){
+      return 0;
+    } else {
+      // don't want commas or else will break on parse.
+      final double duration = Double.parseDouble(time.replaceAll(",", ""));
+      return (long) (duration * 1000);
+    }
   }
 }

--- a/src/test/java/hudson/plugins/performance/JUnitParserTest.java
+++ b/src/test/java/hudson/plugins/performance/JUnitParserTest.java
@@ -2,7 +2,11 @@ package hudson.plugins.performance;
 
 import org.junit.Test;
 
+import java.io.File;
+import java.net.URISyntaxException;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class JUnitParserTest {
 
@@ -16,6 +20,20 @@ public class JUnitParserTest {
     assertEquals("Test having a time with commas will work.", JUnitParser.parseDuration("34,953.254"), (long) 34953254);
     assertEquals("Test having a time with multiple commas will work.", JUnitParser.parseDuration("1,134,953.254"), (long) 1134953254);
     assertEquals("Test that time with no commas still work.", JUnitParser.parseDuration("999.999"), (long) 999999);
+  }
+
+  @Test
+  public void testCanParseFileWithoutTimeAtrribute() throws Exception {
+    final JUnitParser parser = new JUnitParser(null);
+    final File reportFile = new File(getClass().getResource("/TEST-JUnitResults-noTimeAttribute.xml").toURI());
+
+    // Execute system under test.
+    final PerformanceReport result = parser.parse(reportFile);
+
+    // Verify results.
+    assertNotNull(result);
+    assertEquals("The source file contains four samples. These should all have been added to the performance report.", 4, result.size());
+
   }
 
 }

--- a/src/test/resources/TEST-JUnitResults-noTimeAttribute.xml
+++ b/src/test/resources/TEST-JUnitResults-noTimeAttribute.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuite failures="0" time="0.100" errors="0" skipped="0" tests="1" name="hudson.plugins.performance.UriReportTest">
+  <testcase classname="hudson.plugins.performance.JUnitParserTest" name="parseWithoutTimeAttribute"/>
+  <testcase time="0.100" classname="hudson.plugins.performance.JUnitParserTest" name="parseWithoutTimeAttribute"/>
+  <testcase classname="hudson.plugins.performance.JUnitParserTest" name="parseWithoutTimeAttribute"/>
+  <testcase time="0.100" classname="hudson.plugins.performance.JUnitParserTest" name="parseWithoutTimeAttribute"/>
+</testsuite>


### PR DESCRIPTION
Check for null value for time taken to execute a Junit test. If it is null, use 0 as the time value.

The right fix would probably be to use change HttpSample.duration attribute from long to Long and set it to null when no information is provided. Doing this type of a change is probably a larger change affecting various parts of the plugin.

This fix is good enough for the time being.