### PR TITLE
JENKINS-18811: Fix for Junit parser not handling errors.

### DIFF
--- a/src/main/java/hudson/plugins/performance/JUnitParser.java
+++ b/src/main/java/hudson/plugins/performance/JUnitParser.java
@@ -83,8 +83,9 @@ public class JUnitParser extends AbstractParser {
           currentSample.setSuccessful(false);
           report.addSample(currentSample);
           status = 0;
-        } else if ("failure".equalsIgnoreCase(qName) && status != 0) {
+        } else if ("error".equalsIgnoreCase(qName) && status != 0) {
           currentSample.setErrorObtained(true);
+          currentSample.setSuccessful(false);
           report.addSample(currentSample);
           status = 0;
         }

--- a/src/test/java/hudson/plugins/performance/JUnitParserTest.java
+++ b/src/test/java/hudson/plugins/performance/JUnitParserTest.java
@@ -3,7 +3,6 @@ package hudson.plugins.performance;
 import org.junit.Test;
 
 import java.io.File;
-import java.net.URISyntaxException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -33,7 +32,19 @@ public class JUnitParserTest {
     // Verify results.
     assertNotNull(result);
     assertEquals("The source file contains four samples. These should all have been added to the performance report.", 4, result.size());
-
   }
 
+  @Test
+  public void testCanParseJunitResultFileWithSuccessErrorAndFailure() throws Exception {
+    final JUnitParser parser = new JUnitParser(null);
+    final File reportFile = new File(getClass().getResource("/TEST-JUnitResults-success-failure-error.xml").toURI());
+
+    // Execute system under test.
+    final PerformanceReport result = parser.parse(reportFile);
+
+    // Verify results.
+    assertNotNull(result);
+    assertEquals("The source file contains 3 samples. These should all have been added to the performance report.", 3, result.size());
+    assertEquals("The source file contains 2 failed samples. 1 test failure and 1 runtime error sample.", 2, result.countErrors());
+  }
 }

--- a/src/test/resources/TEST-JUnitResults-success-failure-error.xml
+++ b/src/test/resources/TEST-JUnitResults-success-failure-error.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuite errors="1" failures="1" hostname="someHostname" name="tests.ATest" tests="3" time="0.069" timestamp="2009-12-19T17:58:59">
+
+    <testcase classname="tests.ATest" name="error" time="0.0060">
+        <error type="java.lang.RuntimeException">java.lang.RuntimeException at tests.ATest.error(ATest.java:11)</error>
+    </testcase>
+
+    <testcase classname="tests.ATest" name="fail" time="0.0020">
+        <failure type="junit.framework.AssertionFailedError">junit.framework.AssertionFailedError: at tests.ATest.fail(ATest.java:9)</failure>
+    </testcase>
+
+    <testcase classname="tests.ATest" name="sucess" time="0.0"/>
+
+</testsuite>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-18811

There was a duplicate else if for "failure", instead of "error".