### PR TITLE
JENKINS-30963: Fix for parsing jtl with CSV data.

### DIFF
--- a/src/main/java/hudson/plugins/performance/JMeterCsvParser.java
+++ b/src/main/java/hudson/plugins/performance/JMeterCsvParser.java
@@ -16,6 +16,8 @@ import java.util.Set;
 public class JMeterCsvParser extends AbstractParser {
 
   public static final String DEFAULT_DELIMITER = ",";
+  public static final String DEFAULT_CSV_FORMAT = "timeStamp,elapsed,label,responseCode,responseMessage,threadName,dataType,success,bytes,Latency";
+  private static final boolean DONT_SKIP_FIRST_LINE = false;
   public final boolean skipFirstLine;
   public final String delimiter;
   public int timestampIdx = -1;
@@ -52,6 +54,10 @@ public class JMeterCsvParser extends AbstractParser {
         || successIdx < 0 || urlIdx < 0) {
       throw new Exception("Missing required column");
     }
+  }
+
+  public JMeterCsvParser(String glob) throws Exception {
+    this(glob, DEFAULT_CSV_FORMAT, DEFAULT_DELIMITER, DONT_SKIP_FIRST_LINE);
   }
 
   @Extension

--- a/src/main/java/hudson/plugins/performance/JMeterParser.java
+++ b/src/main/java/hudson/plugins/performance/JMeterParser.java
@@ -184,8 +184,7 @@ public class JMeterParser extends AbstractParser {
    * A delegate for {@link #parse(File)} that can process CSV data.
    */
   PerformanceReport parseCsv(File reportFile) throws Exception {
-    // TODO The arguments in this constructor should be configurable.
-    final JMeterCsvParser delegate = new JMeterCsvParser(this.glob, "timestamp,elapsed,URL,responseCode,success", ",", false);
+    final JMeterCsvParser delegate = new JMeterCsvParser(this.glob);
     return delegate.parse(reportFile);
   }
 

--- a/src/test/java/hudson/plugins/performance/JMeterParserTest.java
+++ b/src/test/java/hudson/plugins/performance/JMeterParserTest.java
@@ -121,6 +121,11 @@ public class JMeterParserTest {
     assertNotNull(result);
     assertEquals("The source file contains three samples. These should all have been added to the performance report.",
         3, result.size());
+
+    UriReport uriReport = result.getUriReportMap().get("GET _ordermgmt_inventory");
+    assertEquals(0, uriReport.countErrors());
+    assertEquals("200", uriReport.getHttpCode());
+    assertEquals("GET /ordermgmt/inventory", uriReport.getUri());
   }
 
 


### PR DESCRIPTION
- Changed to use correct default CSV format.

- Added additional verification in test to verify jtl file
  with CSV data is being parsed correctly.