### PR TITLE
[FIXES JENKINS-21405] Fix for Jmeter summariser parser not showing co…

### DIFF
--- a/src/main/java/hudson/plugins/performance/JmeterSummarizerParser.java
+++ b/src/main/java/hudson/plugins/performance/JmeterSummarizerParser.java
@@ -49,54 +49,80 @@ public class JmeterSummarizerParser extends AbstractParser {
   PerformanceReport parse(File reportFile) throws Exception {
     final PerformanceReport report = new PerformanceReport();
     report.setReportFileName(reportFile.getName());
-    report.setReportFileName(reportFile.getName());
 
-    Scanner s = null;
+    Scanner fileScanner = null;
     try {
-      s = new Scanner(reportFile);
+      fileScanner = new Scanner(reportFile);
       String key;
       String line;
       SimpleDateFormat dateFormat = new SimpleDateFormat(logDateFormat);
-
-      while (s.hasNextLine()) {
-        line = s.nextLine().replaceAll("=", " ");
-        if (line.contains("+") && line.contains("jmeter.reporters.Summariser:")) {
-          Scanner scanner = null;
-          try {
-            scanner = new Scanner(line);
-            final Pattern delimiter = scanner.delimiter();
-            scanner.useDelimiter("INFO"); // as jmeter logs INFO mode
-            final HttpSample sample = new HttpSample();
-            final String dateString = scanner.next();
-            sample.setDate(dateFormat.parse(dateString));
-            scanner.findInLine("jmeter.reporters.Summariser:");
-            scanner.useDelimiter("\\+");
-            key = scanner.next().trim();
-            scanner.useDelimiter(delimiter);
-            scanner.next();
-            sample.setSummarizerSamples(scanner.nextLong()); // set SamplesCount
-            scanner.findInLine("Avg:"); // set response time
-            sample.setDuration(scanner.nextLong());
-            sample.setSuccessful(true);
-            scanner.findInLine("Min:"); // set MIN
-            sample.setSummarizerMin(scanner.nextLong());
-            scanner.findInLine("Max:"); // set MAX
-            sample.setSummarizerMax(scanner.nextLong());
-            scanner.findInLine("Err:"); // set errors count
-            sample.setSummarizerErrors(scanner.nextInt());
-            // sample.setSummarizerErrors(
-            // Float.valueOf(scanner.next().replaceAll("[()%]","")));
-            sample.setUri(key);
-            report.addSample(sample);
-          } finally {
-            if (scanner != null) scanner.close();
-          }
+      String lastEqualsLine = null;
+      while (fileScanner.hasNextLine()) {
+        line = fileScanner.nextLine();
+        if (line.contains("=") && line.contains("jmeter.reporters.Summariser:")) {
+          lastEqualsLine = line;
         }
       }
 
+      long reportSamples = Long.MIN_VALUE;
+      long reportAvg = Long.MIN_VALUE;
+      long reportMin = Long.MAX_VALUE;
+      long reportMax = Long.MIN_VALUE;
+      String reportErrorPercent = "";
+      Scanner lineScanner = null;
+      if (lastEqualsLine != null) {
+        try {
+          lineScanner = new Scanner(lastEqualsLine);
+          final Pattern delimiter = lineScanner.delimiter();
+          lineScanner.useDelimiter("INFO"); // as jmeter logs INFO mode
+          final HttpSample sample = new HttpSample();
+          final String dateString = lineScanner.next();
+          sample.setDate(dateFormat.parse(dateString));
+          lineScanner.findInLine("jmeter.reporters.Summariser:");
+          lineScanner.useDelimiter("\\=");
+          key = lineScanner.next().trim();
+          lineScanner.useDelimiter(delimiter);
+          lineScanner.next();
+          reportSamples = lineScanner.nextLong();
+          sample.setSummarizerSamples(reportSamples); // set SamplesCount
+          lineScanner.findInLine("Avg:"); // set response time
+          sample.setDuration(lineScanner.nextLong());
+          reportAvg = sample.getDuration();
+          sample.setSuccessful(true);
+
+          lineScanner.findInLine("Min:"); // set MIN
+          long sampleMin = lineScanner.nextLong();
+          sample.setSummarizerMin(sampleMin);
+          reportMin = Math.min(reportMin, sampleMin);
+
+          lineScanner.findInLine("Max:"); // set MAX
+          long sampleMax = lineScanner.nextLong();
+          sample.setSummarizerMax(sampleMax);
+          reportMax = Math.max(reportMax, sampleMax);
+
+          lineScanner.findInLine("Err:"); // set errors count
+          lineScanner.findInLine("\\("); // set errors count
+          lineScanner.useDelimiter("%");
+          reportErrorPercent = lineScanner.next();
+          sample.setSummarizerErrors(Float.parseFloat(reportErrorPercent));
+          // sample.setSummarizerErrors(
+          // Float.valueOf(scanner.next().replaceAll("[()%]","")));
+          sample.setUri(key);
+          report.addSample(sample);
+        } finally {
+          if (lineScanner != null) lineScanner.close();
+        }
+      }
+
+      report.setSummarizerSize(reportSamples);
+      report.setSummarizerAvg(reportAvg);
+      report.setSummarizerMin(reportMin);
+      report.setSummarizerMax(reportMax);
+      report.setSummarizerErrors(reportErrorPercent);
+
       return report;
     } finally {
-      if (s != null) s.close();
+      if (fileScanner != null) fileScanner.close();
     }
   }
 }

--- a/src/main/java/hudson/plugins/performance/PerformanceReport.java
+++ b/src/main/java/hudson/plugins/performance/PerformanceReport.java
@@ -69,6 +69,11 @@ public class PerformanceReport extends AbstractReport implements Serializable,
    * The size of all samples combined, in kilobytes.
    */
   private double totalSizeInKB = 0;
+  private long summarizerMin;
+  private long summarizerMax;
+  private long summarizerAvg;
+  private String summarizerErrorPercent = null;
+  private long summarizerSize;
 
   public static String asStaplerURI(String uri) {
     return uri.replace("http:", "").replaceAll("/", "_");
@@ -321,5 +326,45 @@ public class PerformanceReport extends AbstractReport implements Serializable,
     BigDecimal bd = new BigDecimal(d);
     bd = bd.setScale(2, RoundingMode.HALF_UP);
     return bd.doubleValue();
+  }
+
+  public void setSummarizerSize(long summarizerSize) {
+    this.summarizerSize = summarizerSize;
+  }
+
+  public long getSummarizerSize() {
+    return summarizerSize;
+  }
+
+  public void setSummarizerMin(long summarizerMin) {
+    this.summarizerMin = summarizerMin;
+  }
+
+  public long getSummarizerMin() {
+    return summarizerMin;
+  }
+
+  public void setSummarizerMax(long summarizerMax) {
+    this.summarizerMax = summarizerMax;
+  }
+
+  public long getSummarizerMax() {
+    return summarizerMax;
+  }
+
+  public void setSummarizerAvg(long summarizerAvg) {
+    this.summarizerAvg = summarizerAvg;
+  }
+
+  public long getSummarizerAvg() {
+    return summarizerAvg;
+  }
+
+  public void setSummarizerErrors(String summarizerErrorPercent) {
+    this.summarizerErrorPercent = summarizerErrorPercent;
+  }
+
+  public String getSummarizerErrors() {
+    return summarizerErrorPercent;
   }
 }

--- a/src/main/resources/hudson/plugins/performance/PerformanceReportMap/index.jelly
+++ b/src/main/resources/hudson/plugins/performance/PerformanceReportMap/index.jelly
@@ -25,7 +25,7 @@
              </td>
            <j:choose>
              <j:when test="${performanceReport.ifSummarizerParserUsed(performanceReport.getReportFileName())}">
-               <jm:summaryTableSummarizer it="${uriReport}" />
+               <jm:summaryTableSummarizer it="${performanceReport}" />
              </j:when>
              <j:otherwise>
                <jm:summaryTable it="${uriReport}" />

--- a/src/test/java/hudson/plugins/performance/JmeterSummarizerParserTest.java
+++ b/src/test/java/hudson/plugins/performance/JmeterSummarizerParserTest.java
@@ -1,21 +1,23 @@
 package hudson.plugins.performance;
 
-import hudson.model.FreeStyleBuild;
 import org.junit.Test;
-import org.jvnet.hudson.test.HudsonTestCase;
 
 import java.io.File;
-import java.net.URL;
-import java.util.Arrays;
 
-public class JmeterSummarizerParserTest extends HudsonTestCase {
+import static org.junit.Assert.assertEquals;
+
+public class JmeterSummarizerParserTest {
 
   @Test
   public void testParse() throws Exception {
-    JmeterSummarizerParser jmeterSummarizerParser = new JmeterSummarizerParser("summary.log", null);
-    URL resource = getClass().getResource("/summary.log");
-    File summaryLogFile = new File(resource.toURI());
-    jmeterSummarizerParser.parse(new FreeStyleBuild(createFreeStyleProject()), Arrays.asList(summaryLogFile), createTaskListener());
-  }
+    JmeterSummarizerParser jmeterSummarizerParser = new JmeterSummarizerParser(null, null);
+    File summaryLogFile = new File(getClass().getResource("/summary.log").toURI());
+    PerformanceReport performanceReport = jmeterSummarizerParser.parse(summaryLogFile);
 
+    assertEquals(1257, performanceReport.getSummarizerSize());
+    assertEquals(333, performanceReport.getSummarizerAvg());
+    assertEquals(3, performanceReport.getSummarizerMin());
+    assertEquals(5630, performanceReport.getSummarizerMax());
+    assertEquals("4.56", performanceReport.getSummarizerErrors());
+  }
 }

--- a/src/test/resources/summary.log
+++ b/src/test/resources/summary.log
@@ -12,4 +12,11 @@
 2014/05/22 14:51:00 INFO  - jmeter.reporters.Summariser: Generate Summary Results +    186 in    43s =    4.3/s Avg:   536 Min:     5 Max:  4617 Err:     0 (0.00%) Active: 5 Started: 5 Finished: 0 
 2014/05/22 14:53:54 INFO  - jmeter.engine.StandardJMeterEngine: Notifying test listeners of end of test 
 2014/05/22 14:53:54 INFO  - jmeter.reporters.Summariser: Generate Summary Results +   1069 in   175s =    6.1/s Avg:   295 Min:    33 Max:  5628 Err:     0 (0.00%) Active: 0 Started: 5 Finished: 5 
-2014/05/22 14:53:54 INFO  - jmeter.reporters.Summariser: Generate Summary Results =   1255 in   217s =    5.8/s Avg:   330 Min:     5 Max:  5628 Err:     0 (0.00%) 
+2014/05/22 14:53:54 INFO  - jmeter.reporters.Summariser: Generate Summary Results =   1255 in   217s =    5.8/s Avg:   330 Min:     5 Max:  5628 Err:     0 (0.00%)
+
+# added made up numbers
+2014/05/22 14:53:54 INFO  - jmeter.reporters.Summariser: Generate Summary Results +      1 in      1 =    1.0/s Avg:   295 Min:    33 Max:  5628 Err:     0 (0.00%) Active: 0 Started: 5 Finished: 5
+2014/05/22 14:53:54 INFO  - jmeter.reporters.Summariser: Generate Summary Results =   1256 in   217s =    6.8/s Avg:   331 Min:     4 Max:  5629 Err:     0 (0.00%)
+# added made up numbers
+2014/05/22 14:53:54 INFO  - jmeter.reporters.Summariser: Generate Summary Results +   1 in   175s =    6.1/s Avg:   295 Min:    33 Max:  5628 Err:     0 (0.00%) Active: 0 Started: 5 Finished: 5
+2014/05/22 14:53:54 INFO  - jmeter.reporters.Summariser: Generate Summary Results =   1257 in   217s =    7.8/s Avg:   333 Min:     3 Max:  5630 Err:     123 (4.56%)


### PR DESCRIPTION
…rrect data.

Summariser report should use the last equals line of the report for data.
Last equals line has the correct avg, min, max.

Summariser report now shows sample size, avg, min, max, error percent.