### PR TITLE
[FIXES JENKINS-28787]: Fixes number format exception

### DIFF
--- a/src/test/java/hudson/plugins/performance/JMeterCsvParserTest.java
+++ b/src/test/java/hudson/plugins/performance/JMeterCsvParserTest.java
@@ -1,5 +1,6 @@
 package hudson.plugins.performance;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -11,17 +12,29 @@ public class JMeterCsvParserTest {
   private static final Boolean SKIP_FIRST_LINE = true;
   private static final String TEST_FILE_PATTERN = "timeStamp,elapsed,label,responseCode,responseMessage,threadName,dataType,success,bytes";
   private static final String NO_GLOB = null;
+  private File reportFile;
+
+  @Before
+  public void beforeMethod() throws Exception {
+    reportFile = new File(getClass().getResource("/JMeterCsvResults.csv").toURI());
+  }
 
   @Test
   public void canParseCsvFile() throws Exception {
-    final File reportFile = new File(getClass().getResource("/JMeterCsvResults.csv").toURI());
-
     final JMeterCsvParser parser = new JMeterCsvParser(NO_GLOB, TEST_FILE_PATTERN, DEFAULT_DELIMITER, SKIP_FIRST_LINE);
-    final PerformanceReport result = parser.parse(reportFile);
+    parseAndVerifyResult(parser);
+  }
 
+  @Test
+  public void canParseCsvFileWhenSkipFirstLineIsNotSpecifiedAndFirstLineHasHeader() throws Exception {
+    final JMeterCsvParser parser = new JMeterCsvParser(NO_GLOB);
+    parseAndVerifyResult(parser);
+  }
+
+  private void parseAndVerifyResult(JMeterCsvParser parser) throws Exception {
+    final PerformanceReport result = parser.parse(reportFile);
     // Verify results.
     assertNotNull(result);
-    assertEquals("The source file contains three samples. These should all have been added to the performance report.",
-        3, result.size());
+    assertEquals("The source file contains three samples. These should all have been added to the performance report.", 3, result.size());
   }
 }


### PR DESCRIPTION
When JMeter parser is used and a csv file contains header line, a number format exception is thrown.
Fix is to check if the first line is a header and skip the line if it is a header.
Note: Noticed that if there was a test for the constructor with glob only, this issue
would have been caught in testing.

Test added and refactored for cleanup.