### PR TITLE
Improve CPU and memory usage on heavy performance test.

### DIFF
--- a/src/main/java/hudson/plugins/performance/AbstractParser.java
+++ b/src/main/java/hudson/plugins/performance/AbstractParser.java
@@ -30,7 +30,7 @@ public abstract class AbstractParser extends PerformanceReportParser {
   /**
    * A cache that contains serialized PerformanceReport instances. This cache intends to limit disc IO.
    */
-  private static final Cache<String, PerformanceReport> CACHE = CacheBuilder.newBuilder().maximumSize(1000).build();
+  private static final Cache<String, PerformanceReport> CACHE = CacheBuilder.newBuilder().maximumSize(1000).softValues().build();
 
   public AbstractParser(String glob) {
     super(glob);

--- a/src/main/java/hudson/plugins/performance/AbstractReport.java
+++ b/src/main/java/hudson/plugins/performance/AbstractReport.java
@@ -11,57 +11,63 @@ import java.util.Locale;
  */
 public abstract class AbstractReport {
 
-  protected final DecimalFormat percentFormat;
-  protected final DecimalFormat dataFormat; // three decimals
+  protected final ThreadLocal<DecimalFormat> percentFormat;
+  protected final ThreadLocal<DecimalFormat> dataFormat; // three decimals
 
   abstract public int countErrors();
 
   abstract public double errorPercent();
 
   public AbstractReport() {
-    final Locale useThisLocale = (Stapler.getCurrentRequest() != null) ? Stapler.getCurrentRequest().getLocale() : Locale.getDefault();
+    final Locale useThisLocale = ( Stapler.getCurrentRequest() != null ) ? Stapler.getCurrentRequest().getLocale() : Locale.getDefault();
 
-    percentFormat = new DecimalFormat("0.0", DecimalFormatSymbols.getInstance(useThisLocale));
-    dataFormat = new DecimalFormat("#,###", DecimalFormatSymbols.getInstance(useThisLocale));
+    percentFormat = new ThreadLocal<DecimalFormat>() {
+
+      @Override
+      protected DecimalFormat initialValue()
+      {
+        return new DecimalFormat("0.0", DecimalFormatSymbols.getInstance(useThisLocale));
+      }
+    };
+
+    dataFormat = new ThreadLocal<DecimalFormat>() {
+
+      @Override
+      protected DecimalFormat initialValue()
+      {
+        return new DecimalFormat("#,###", DecimalFormatSymbols.getInstance( useThisLocale ));
+      }
+    };
+
   }
 
   public String errorPercentFormated() {
     Stapler.getCurrentRequest().getLocale();
-    synchronized (percentFormat) {
-      return percentFormat.format(errorPercent());
-    }
+    return percentFormat.get().format(errorPercent());
   }
 
   abstract public long getAverage();
 
   public String getAverageFormated() {
-    synchronized (dataFormat) {
-      return dataFormat.format(getAverage());
-    }
+    return dataFormat.get().format(getAverage());
   }
 
   abstract public long getMedian();
 
   public String getMeanFormated() {
-    synchronized (dataFormat) {
-      return dataFormat.format(getMedian());
-    }
+    return dataFormat.get().format(getMedian());
   }
 
   abstract public long get90Line();
 
   public String get90LineFormated() {
-    synchronized (dataFormat) {
-      return dataFormat.format(get90Line());
-    }
+    return dataFormat.get().format(get90Line());
   }
 
   abstract public long getMax();
 
   public String getMaxFormated() {
-    synchronized (dataFormat) {
-      return dataFormat.format(getMax());
-    }
+    return dataFormat.get().format(getMax());
   }
 
   abstract public long getMin();


### PR DESCRIPTION
I have several projects that use **performance-plugin** with a huge quantity of jmeter result.

- The cache implemented cause very often jenkins  run out of memory. Using `softValues` allow to free cache memory when jenkins run out of memory.
- To reduce CPU usage I remove `synchronized` block by using `ThreadLocal` `DecimalFormat`.

Thx for your plugin.

