### PR TITLE
Setting build results for certain unstable result codepaths

### DIFF
--- a/src/main/java/hudson/plugins/performance/PerformancePublisher.java
+++ b/src/main/java/hudson/plugins/performance/PerformancePublisher.java
@@ -422,6 +422,7 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
                 run.setResult(Result.FAILURE);
               } else if (errorUnstableThreshold >= 0 && errorPercent - errorUnstableThreshold > thresholdTolerance) {
                 result = Result.UNSTABLE;
+                run.setResult(Result.UNSTABLE);
               }
 
               long average = r.getAverage();
@@ -760,6 +761,7 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
                         && Math.abs(relativeDiffPercent) - relativeUnstableThresholdNegative > thresholdTolerance) {
 
                       result = Result.UNSTABLE;
+                      run.setResult(Result.UNSTABLE);
                       unStableLabel = prevuriList.get(i).getStaplerUri();
                     }
                   } else if (relativeDiffPercent >= 0) {
@@ -775,6 +777,7 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
                         && Math.abs(relativeDiffPercent) - relativeUnstableThresholdPositive > thresholdTolerance) {
 
                       result = Result.UNSTABLE;
+                      run.setResult(Result.UNSTABLE);
                       unStableLabel = prevuriList.get(i).getStaplerUri();
                     }
                   }


### PR DESCRIPTION
Certain codepaths that should result in setting a build to unstable don't seem to be setting the run result.