### PR TITLE
If we have no parsedReports, do not access a null pointer.

### DIFF
--- a/src/main/java/hudson/plugins/performance/PerformancePublisher.java
+++ b/src/main/java/hudson/plugins/performance/PerformancePublisher.java
@@ -299,7 +299,7 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
         run.setResult(Result.SUCCESS);
         EnvVars env = run.getEnvironment(listener);
 
-        Collection<PerformanceReport> parsedReports = null;
+        Collection<PerformanceReport> parsedReports = Collections.emptyList();
         String glob = null;
 
         /**


### PR DESCRIPTION
This fixes the problem described here:
https://groups.google.com/forum/#!searchin/codename-taurus/rodrigues%7Csort:relevance/codename-taurus/kCXkIOyynio/hGUMbHmvFAAJ