### PR TITLE
choose graph type based on failure condition

### DIFF
--- a/src/main/java/hudson/plugins/performance/PerformancePublisher.java
+++ b/src/main/java/hudson/plugins/performance/PerformancePublisher.java
@@ -99,6 +99,8 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
 
     private String configType = "ART";
 
+    private String graphType = "ART";
+
     private boolean modeOfThreshold = false;
 
     private boolean failBuildIfNoResultFile = false;
@@ -1144,6 +1146,15 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
         this.configType = configType;
     }
 
+    public String getGraphType() {
+        return graphType;
+    }
+
+    @DataBoundSetter
+    public void setGraphType(String graphType) {
+        this.graphType = graphType;
+    }
+
     public boolean getModeOfThreshold() {
         return modeOfThreshold;
     }
@@ -1361,12 +1372,18 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
          * @return the name of the option selected in the previous run
          */
         public ListBoxModel doFillConfigTypeItems() {
-            ListBoxModel items = new ListBoxModel();
+            return getResponseTimeOptions();
+        }
 
+        public ListBoxModel doFillGraphTypeItems() {
+            return getResponseTimeOptions();
+        }
+
+        private ListBoxModel getResponseTimeOptions() {
+            ListBoxModel items = new ListBoxModel();
             items.add("Average Response Time", "ART");
             items.add("Median Response Time", "MRT");
             items.add("Percentile Response Time", "PRT");
-
             return items;
         }
     }

--- a/src/main/java/hudson/plugins/performance/PerformanceReportMap.java
+++ b/src/main/java/hudson/plugins/performance/PerformanceReportMap.java
@@ -15,6 +15,9 @@ import hudson.plugins.performance.reports.UriReport;
 import hudson.util.ChartUtil;
 import hudson.util.ChartUtil.NumberOnlyBuildLabel;
 import hudson.util.DataSetBuilder;
+
+import org.jfree.chart.JFreeChart;
+import org.jfree.data.category.CategoryDataset;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -202,8 +205,12 @@ public class PerformanceReportMap implements ModelObject {
             dataSetBuilder.add(valueSelector.getValue(report),
                     keyLabel, label);
         }
-        ChartUtil.generateGraph(request, response, PerformanceProjectAction
-                .createRespondingTimeChart(dataSetBuilder.build()), 400, 200);
+        ChartUtil.generateGraph(request, response,
+                createRespondingTimeChart(dataSetBuilder.build()), 400, 200);
+    }
+
+    protected JFreeChart createRespondingTimeChart(CategoryDataset dataset) {
+        return PerformanceProjectAction.doCreateRespondingTimeChart(dataset);
     }
 
     private String getKeyLabel(String configType) {
@@ -259,12 +266,14 @@ public class PerformanceReportMap implements ModelObject {
         ChartUtil.generateGraph(
                 request,
                 response,
-                PerformanceProjectAction.createSummarizerChart(
-                        dataSetBuilderSummarizer.build(), "ms",
-                        Messages.ProjectAction_RespondingTime()), 400, 200);
+                createSummarizerChart(dataSetBuilderSummarizer.build()), 400, 200);
     }
 
-    private void parseReports(Run<?, ?> build, TaskListener listener,
+    protected JFreeChart createSummarizerChart(CategoryDataset dataset) {
+        return PerformanceProjectAction.doCreateSummarizerChart(dataset, "ms", Messages.ProjectAction_RespondingTime());
+    }
+
+    protected void parseReports(Run<?, ?> build, TaskListener listener,
                               PerformanceReportCollector collector, final String filename)
             throws IOException {
         File repo = new File(build.getRootDir(),
@@ -360,7 +369,7 @@ public class PerformanceReportMap implements ModelObject {
         }
     }
 
-    private interface PerformanceReportCollector {
+    protected interface PerformanceReportCollector {
 
         public void addAll(Collection<PerformanceReport> parse);
     }

--- a/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
+++ b/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
@@ -54,7 +54,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public final class PerformanceProjectAction implements Action {
+public class PerformanceProjectAction implements Action {
 
     private static final String CONFIGURE_LINK = "configure";
     private static final String TRENDREPORT_LINK = "trendReport";
@@ -142,7 +142,7 @@ public final class PerformanceProjectAction implements Action {
         return chart;
     }
 
-    public static JFreeChart createRespondingTimeChart(CategoryDataset dataset) {
+    public static JFreeChart doCreateRespondingTimeChart(CategoryDataset dataset) {
 
         final JFreeChart chart = ChartFactory.createLineChart(
                 Messages.ProjectAction_RespondingTime(), // charttitle
@@ -236,8 +236,8 @@ public final class PerformanceProjectAction implements Action {
         return chart;
     }
 
-    public static JFreeChart createSummarizerChart(CategoryDataset dataset,
-                                                      String yAxis, String chartTitle) {
+    public static JFreeChart doCreateSummarizerChart(CategoryDataset dataset,
+                                                     String yAxis, String chartTitle) {
 
         final JFreeChart chart = ChartFactory.createBarChart(chartTitle, // chart
                 // title
@@ -390,14 +390,7 @@ public final class PerformanceProjectAction implements Action {
                 if (!buildsLimits.includedByStep(build.number)) {
                     continue;
                 }
-                PerformanceBuildAction performanceBuildAction = build
-                        .getAction(PerformanceBuildAction.class);
-                if (performanceBuildAction == null) {
-                    continue;
-                }
-                PerformanceReport performanceReport = performanceBuildAction
-                        .getPerformanceReportMap().getPerformanceReport(
-                                performanceReportNameFile);
+                PerformanceReport performanceReport = getPerformanceReport(build, performanceReportNameFile);
                 if (performanceReport == null) {
                     nbBuildsToAnalyze--;
                     continue;
@@ -412,7 +405,20 @@ public final class PerformanceProjectAction implements Action {
         }
         ChartUtil.generateGraph(request, response,
                 createRespondingTimeChart(dataSetBuilder.build()), 600, 200);
+    }
 
+    protected PerformanceReport getPerformanceReport(Run<?, ?> build, String reportFileName) {
+        PerformanceBuildAction performanceBuildAction = build.getAction(PerformanceBuildAction.class);
+        if (performanceBuildAction == null) {
+            return null;
+        }
+        return performanceBuildAction
+                .getPerformanceReportMap()
+                .getPerformanceReport(reportFileName);
+    }
+
+    protected JFreeChart createRespondingTimeChart(CategoryDataset dataset) {
+        return doCreateRespondingTimeChart(dataset);
     }
 
     public void doRespondingTimeGraph(StaplerRequest request, StaplerResponse response) throws IOException {
@@ -535,15 +541,7 @@ public final class PerformanceProjectAction implements Action {
             Run<?, ?> currentBuild = (Run<?, ?>) build;
             if (buildsLimits.in(nbBuildsToAnalyze)) {
                 NumberOnlyBuildLabel label = new NumberOnlyBuildLabel(currentBuild);
-                PerformanceBuildAction performanceBuildAction = currentBuild
-                        .getAction(PerformanceBuildAction.class);
-                if (performanceBuildAction == null) {
-                    continue;
-                }
-                PerformanceReport performanceReport = performanceBuildAction
-                        .getPerformanceReportMap().getPerformanceReport(
-                                performanceReportNameFile);
-
+                PerformanceReport performanceReport = getPerformanceReport(currentBuild, performanceReportNameFile);
                 if (performanceReport == null) {
                     nbBuildsToAnalyze--;
                     continue;
@@ -575,6 +573,10 @@ public final class PerformanceProjectAction implements Action {
                     createSummarizerChart(dataSetBuilderSummarizer.build(), "ms",
                             Messages.ProjectAction_RespondingTime()), 400, 200);
         }
+    }
+
+    protected JFreeChart createSummarizerChart(CategoryDataset dataset, String yAxis, String chartTitle) {
+        return doCreateSummarizerChart(dataset, yAxis, chartTitle);
     }
 
     /**

--- a/src/main/java/hudson/plugins/performance/data/ReportValueSelector.java
+++ b/src/main/java/hudson/plugins/performance/data/ReportValueSelector.java
@@ -1,0 +1,75 @@
+package hudson.plugins.performance.data;
+
+import hudson.model.AbstractProject;
+import hudson.model.Job;
+import hudson.plugins.performance.PerformancePublisher;
+import hudson.plugins.performance.reports.AbstractReport;
+
+public abstract class ReportValueSelector {
+
+    public abstract long getValue(AbstractReport report);
+
+    public abstract String getGraphType();
+
+    public static ReportValueSelector get(Job<?, ?> job) {
+        if (job instanceof AbstractProject) {
+            // can't get a AbstractProject reference from PerformanceReportMap :/
+            AbstractProject<?, ?> project = (AbstractProject<?, ?>) job;
+            return get(project.getPublishersList().get(PerformancePublisher.class));
+        }
+        return get((PerformancePublisher) null);
+    }
+
+    public static ReportValueSelector get(PerformancePublisher publisher) {
+        if (publisher == null)
+            return new SelectAverage();
+
+        String graphType = publisher.getGraphType();
+        if (graphType == null)
+            return new SelectAverage();
+        if (graphType.equals(PerformancePublisher.MRT))
+            return new SelectMedian();
+        if (graphType.equals(PerformancePublisher.PRT))
+            return new SelectPercentile();
+        return new SelectAverage(); // default
+    }
+
+    private static class SelectAverage extends ReportValueSelector {
+
+        @Override
+        public long getValue(AbstractReport report) {
+            return report.getAverage();
+        }
+
+        @Override
+        public String getGraphType() {
+            return PerformancePublisher.ART;
+        }
+    }
+
+    private static class SelectMedian extends ReportValueSelector {
+
+        @Override
+        public long getValue(AbstractReport report) {
+            return report.getMedian();
+        }
+
+        @Override
+        public String getGraphType() {
+            return PerformancePublisher.MRT;
+        }
+    }
+
+    private static class SelectPercentile extends ReportValueSelector {
+
+        @Override
+        public long getValue(AbstractReport report) {
+            return report.get90Line();
+        }
+
+        @Override
+        public String getGraphType() {
+            return PerformancePublisher.PRT;
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/performance/details/TestSuiteReportDetail.java
+++ b/src/main/java/hudson/plugins/performance/details/TestSuiteReportDetail.java
@@ -6,6 +6,7 @@ import hudson.model.Run;
 import hudson.plugins.performance.Messages;
 import hudson.plugins.performance.actions.PerformanceBuildAction;
 import hudson.plugins.performance.actions.PerformanceProjectAction.Range;
+import hudson.plugins.performance.data.ReportValueSelector;
 import hudson.plugins.performance.reports.PerformanceReport;
 import hudson.plugins.performance.reports.UriReport;
 import hudson.util.ChartUtil;
@@ -66,7 +67,8 @@ public class TestSuiteReportDetail implements ModelObject {
     }
 
     DataSetBuilder<String, NumberOnlyBuildLabel> getChartDatasetBuilderForBuilds(String testUri, List<? extends Run<?, ?>> builds) {
-        DataSetBuilder<String, NumberOnlyBuildLabel> dataSetBuilderAverage = new DataSetBuilder<String, NumberOnlyBuildLabel>();
+        DataSetBuilder<String, NumberOnlyBuildLabel> dataSetBuilder = new DataSetBuilder<String, NumberOnlyBuildLabel>();
+        ReportValueSelector valueSelector = ReportValueSelector.get(getProject());
         int nbBuildsToAnalyze = builds.size();
         for (Run<?, ?> build : builds) {
             if (buildsLimits.in(nbBuildsToAnalyze)) {
@@ -90,12 +92,12 @@ public class TestSuiteReportDetail implements ModelObject {
                 String testStaplerUri = PerformanceReport.asStaplerURI(testUri);
                 UriReport reportForTestUri = performanceReport.getUriReportMap().get(testStaplerUri);
                 if (reportForTestUri != null) {
-                    dataSetBuilderAverage.add(reportForTestUri.getAverage(), testUri, label);
+                    dataSetBuilder.add(valueSelector.getValue(reportForTestUri), testUri, label);
                 }
             }
             nbBuildsToAnalyze--;
         }
-        return dataSetBuilderAverage;
+        return dataSetBuilder;
     }
 
     protected static JFreeChart createRespondingTimeChart(CategoryDataset dataset) {

--- a/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.jelly
@@ -25,6 +25,14 @@
       </tbody>
     </table>
   </f:entry>
+
+  <f:entry field="graphType" name="graphType" title="Select graphed metric">
+    <f:select name="graphType">
+      <option value="ART">Average Response Time</option>
+      <option value="MRT">Median Response Time</option>
+      <option value="PRT">90% Response Time</option>
+    </f:select>
+  </f:entry>
   
   <f:entry title="Select evaluation mode" field="modeEvaluation">
     <f:booleanRadio name="modeEvaluation"  false="Standard Mode" true="Expert Mode" />

--- a/src/test/java/hudson/plugins/performance/AbstractGraphGenerationTest.java
+++ b/src/test/java/hudson/plugins/performance/AbstractGraphGenerationTest.java
@@ -1,0 +1,61 @@
+package hudson.plugins.performance;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.ServletOutputStream;
+
+import org.jfree.data.category.CategoryDataset;
+import org.junit.Before;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.mockito.Mock;
+
+import hudson.model.AbstractProject;
+import hudson.model.Run;
+import hudson.plugins.performance.parsers.JMeterTestHelper;
+import hudson.plugins.performance.reports.PerformanceReport;
+import hudson.util.DescribableList;
+
+
+public abstract class AbstractGraphGenerationTest {
+
+    @Mock
+    protected AbstractProject project;
+    @Mock
+    protected Run build;
+    @Mock
+    protected StaplerRequest request;
+    @Mock
+    protected StaplerResponse response;
+
+    protected PerformanceReport report;
+
+    @Before
+    public void baseSetup() throws Exception {
+        report = JMeterTestHelper.parse("/JMeterResults.jtl");
+        when(build.getDisplayName()).thenReturn("mock");
+        when(response.getOutputStream()).thenReturn(mock(ServletOutputStream.class));
+    }
+
+    protected void setGraphType(String graphType) {
+        DescribableList list = mock(DescribableList.class);
+        when(project.getPublishersList()).thenReturn(list);
+        PerformancePublisher publisher = mock(PerformancePublisher.class);
+        when(list.get(PerformancePublisher.class)).thenReturn(publisher);
+        when(publisher.getGraphType()).thenReturn(graphType);
+    }
+
+    protected Number[] toArray(CategoryDataset cd) {
+        List<Number> values = new ArrayList<>();
+        for (int i = 0; i < cd.getRowCount(); i++) {
+            for (int j = 0; j < cd.getColumnCount(); j++) {
+                values.add(cd.getValue(i, j));
+            }
+        }
+        return values.toArray(new Number[0]);
+    }
+}

--- a/src/test/java/hudson/plugins/performance/PerformanceReportMapTest.java
+++ b/src/test/java/hudson/plugins/performance/PerformanceReportMapTest.java
@@ -1,0 +1,88 @@
+package hudson.plugins.performance;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.jfree.chart.JFreeChart;
+import org.jfree.data.category.CategoryDataset;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.performance.actions.PerformanceBuildAction;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PerformanceReportMapTest extends AbstractGraphGenerationTest {
+
+    private TestablePerformanceReportMap target;
+
+    @Before
+    public void reportMapSetup() throws Exception {
+        PerformanceBuildAction buildAction = mock(PerformanceBuildAction.class);
+        when(buildAction.getBuild()).thenReturn(build);
+        when(build.getParent()).thenReturn(project);
+        when(request.getParameter("performanceReportPosition")).thenReturn("JMeterResults.jtl");
+        target = new TestablePerformanceReportMap(buildAction, mock(TaskListener.class));
+    }
+
+    @Test
+    public void testRespondingTimeGraphAverageValues() throws Exception {
+        setGraphType(PerformancePublisher.ART);
+        target.doRespondingTimeGraph(request, response);
+        assertArrayEquals(new Number[]{4142L}, toArray(target.dataset));
+    }
+
+    @Test
+    public void testRespondingTimeGraphMedianValues() throws Exception {
+        setGraphType(PerformancePublisher.MRT);
+        target.doRespondingTimeGraph(request, response);
+        assertArrayEquals(new Number[]{501L}, toArray(target.dataset));
+    }
+
+    @Test
+    public void testSummarizerGraphAverageValues() throws Exception {
+        setGraphType(PerformancePublisher.ART);
+        target.doSummarizerGraph(request, response);
+        assertArrayEquals(new Number[]{7930L, 354L}, toArray(target.dataset));
+    }
+
+    @Test
+    public void testSummarizerGraphMedianValues() throws Exception {
+        setGraphType(PerformancePublisher.MRT);
+        target.doSummarizerGraph(request, response);
+        assertArrayEquals(new Number[]{14720L, 278L}, toArray(target.dataset));
+    }
+
+    public class TestablePerformanceReportMap extends PerformanceReportMap {
+
+        public CategoryDataset dataset;
+
+        public TestablePerformanceReportMap(PerformanceBuildAction buildAction, TaskListener listener) throws IOException {
+            super(buildAction, listener);
+        }
+
+        @Override
+        protected JFreeChart createRespondingTimeChart(CategoryDataset dataset) {
+            this.dataset = dataset;
+            return super.createRespondingTimeChart(dataset);
+        }
+
+        @Override
+        protected JFreeChart createSummarizerChart(CategoryDataset dataset) {
+            this.dataset = dataset;
+            return super.createSummarizerChart(dataset);
+        }
+
+        @Override
+        protected void parseReports(Run<?, ?> build, TaskListener listener, PerformanceReportCollector collector, String filename) {
+            collector.addAll(Collections.singletonList(report));
+        }
+    }
+}

--- a/src/test/java/hudson/plugins/performance/actions/PerformanceProjectActionGraphTest.java
+++ b/src/test/java/hudson/plugins/performance/actions/PerformanceProjectActionGraphTest.java
@@ -1,0 +1,95 @@
+package hudson.plugins.performance.actions;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
+import org.jfree.chart.JFreeChart;
+import org.jfree.data.category.CategoryDataset;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import hudson.model.AbstractProject;
+import hudson.model.Run;
+import hudson.plugins.performance.AbstractGraphGenerationTest;
+import hudson.plugins.performance.PerformancePublisher;
+import hudson.plugins.performance.reports.PerformanceReport;
+import hudson.util.RunList;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PerformanceProjectActionGraphTest extends AbstractGraphGenerationTest {
+
+    private TestablePerformanceProjectAction target;
+
+    @Before
+    public void actionSetup() throws Exception {
+        when(project.getBuilds()).thenReturn(RunList.fromRuns(Collections.singletonList(build)));
+        target = new TestablePerformanceProjectAction(project);
+    }
+
+    @Test
+    public void testRespondingTimeGraphPerTestCaseModeAverageValues() throws Exception {
+        setGraphType(PerformancePublisher.ART);
+        target.doRespondingTimeGraphPerTestCaseMode(request, response);
+        assertArrayEquals(new Number[]{7930L, 354L}, toArray(target.dataset));
+    }
+
+    @Test
+    public void testRespondingTimeGraphPerTestCaseModeMedianValues() throws Exception {
+        setGraphType(PerformancePublisher.MRT);
+        target.doRespondingTimeGraphPerTestCaseMode(request, response);
+        assertArrayEquals(new Number[]{14720L, 278L}, toArray(target.dataset));
+    }
+
+    @Test
+    public void testSummarizerGraphAverageValues() throws Exception {
+        setGraphType(PerformancePublisher.ART);
+        target.doSummarizerGraph(request, response);
+        assertArrayEquals(new Number[]{7930L, 354L}, toArray(target.dataset));
+    }
+
+    @Test
+    public void testSummarizerGraphMedianValues() throws Exception {
+        setGraphType(PerformancePublisher.MRT);
+        target.doSummarizerGraph(request, response);
+        assertArrayEquals(new Number[]{14720L, 278L}, toArray(target.dataset));
+    }
+
+    private class TestablePerformanceProjectAction extends PerformanceProjectAction {
+
+        public CategoryDataset dataset;
+
+        public TestablePerformanceProjectAction(AbstractProject<?, ?> project) {
+            super(project);
+        }
+
+        @Nonnull
+        @Override
+        public List<String> getPerformanceReportList() {
+            return Collections.singletonList("JMeterResults.jtl");
+        }
+
+        @Override
+        protected PerformanceReport getPerformanceReport(Run<?, ?> build, String reportFileName) {
+            return report;
+        }
+
+        @Override
+        protected JFreeChart createRespondingTimeChart(CategoryDataset dataset) {
+            this.dataset = dataset;
+            return super.createRespondingTimeChart(dataset);
+        }
+
+        @Override
+        protected JFreeChart createSummarizerChart(CategoryDataset dataset, String yAxis, String chartTitle) {
+            this.dataset = dataset;
+            return super.createSummarizerChart(dataset, yAxis, chartTitle);
+        }
+    }
+}

--- a/src/test/java/hudson/plugins/performance/data/ReportValueSelectorTest.java
+++ b/src/test/java/hudson/plugins/performance/data/ReportValueSelectorTest.java
@@ -1,0 +1,87 @@
+package hudson.plugins.performance.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import hudson.model.AbstractProject;
+import hudson.plugins.performance.PerformancePublisher;
+import hudson.plugins.performance.reports.AbstractReport;
+import hudson.util.DescribableList;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReportValueSelectorTest {
+
+    private static final long VALUE_ART = 1L;
+    private static final long VALUE_MRT = 2L;
+    private static final long VALUE_PRT = 3L;
+
+    @Mock
+    private PerformancePublisher publisher;
+    @Mock
+    private AbstractReport report;
+
+    @Before
+    public void setUp() throws Exception {
+        when(report.getAverage()).thenReturn(VALUE_ART);
+        when(report.getMedian()).thenReturn(VALUE_MRT);
+        when(report.get90Line()).thenReturn(VALUE_PRT);
+    }
+
+    @Test
+    public void testAverageConfiguration() throws Exception {
+        when(publisher.getGraphType()).thenReturn(PerformancePublisher.ART);
+        ReportValueSelector valueSelector = ReportValueSelector.get(publisher);
+        assertEquals(VALUE_ART, valueSelector.getValue(report));
+        assertEquals(PerformancePublisher.ART, valueSelector.getGraphType());
+    }
+
+    @Test
+    public void testMedianConfiguration() throws Exception {
+        when(publisher.getGraphType()).thenReturn(PerformancePublisher.MRT);
+        ReportValueSelector valueSelector = ReportValueSelector.get(publisher);
+        assertEquals(VALUE_MRT, valueSelector.getValue(report));
+        assertEquals(PerformancePublisher.MRT, valueSelector.getGraphType());
+    }
+
+    @Test
+    public void testPercentileConfiguration() throws Exception {
+        when(publisher.getGraphType()).thenReturn(PerformancePublisher.PRT);
+        ReportValueSelector valueSelector = ReportValueSelector.get(publisher);
+        assertEquals(VALUE_PRT, valueSelector.getValue(report));
+        assertEquals(PerformancePublisher.PRT, valueSelector.getGraphType());
+    }
+
+    @Test
+    public void testFallbackNoPublisher() throws Exception {
+        ReportValueSelector valueSelector = ReportValueSelector.get((PerformancePublisher) null);
+        assertEquals(VALUE_ART, valueSelector.getValue(report));
+        assertEquals(PerformancePublisher.ART, valueSelector.getGraphType());
+    }
+
+    @Test
+    public void testFallbackMissingGraphConfig() throws Exception {
+        when(publisher.getGraphType()).thenReturn(null);
+        ReportValueSelector valueSelector = ReportValueSelector.get(publisher);
+        assertEquals(VALUE_ART, valueSelector.getValue(report));
+        assertEquals(PerformancePublisher.ART, valueSelector.getGraphType());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testPublisherSearchedFromAbstractProject() throws Exception {
+        AbstractProject project = mock(AbstractProject.class);
+        DescribableList publishers = mock(DescribableList.class);
+        when(project.getPublishersList()).thenReturn(publishers);
+        when(publishers.get(PerformancePublisher.class)).thenReturn(publisher);
+        when(publisher.getGraphType()).thenReturn(PerformancePublisher.MRT);
+        ReportValueSelector valueSelector = ReportValueSelector.get(project);
+        assertEquals(PerformancePublisher.MRT, valueSelector.getGraphType());
+        verify(publishers, atLeastOnce()).get(PerformancePublisher.class);
+    }
+}

--- a/src/test/java/hudson/plugins/performance/details/TestSuiteReportDetailTest.java
+++ b/src/test/java/hudson/plugins/performance/details/TestSuiteReportDetailTest.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import hudson.model.Descriptor;
 import hudson.model.FreeStyleProject;
 import hudson.plugins.performance.PerformanceReportMap;
 import hudson.plugins.performance.actions.PerformanceBuildAction;
@@ -31,7 +32,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 import hudson.model.FreeStyleBuild;
 import hudson.model.Project;
 import hudson.model.Run;
+import hudson.tasks.Publisher;
 import hudson.util.ChartUtil;
+import hudson.util.DescribableList;
 import hudson.util.RunList;
 
 
@@ -43,6 +46,8 @@ public class TestSuiteReportDetailTest {
 
     @Mock
     FreeStyleBuild run;
+    @Mock
+    Project<?, ?> project;
     @Mock
     PerformanceReportMap reportMap;
     @Mock
@@ -85,11 +90,12 @@ public class TestSuiteReportDetailTest {
     public void chartDatasetHasAverageOfSamples() throws Exception {
         run.number = 1;
         when(run.getAction(PerformanceBuildAction.class)).thenReturn(buildAction);
+        when(project.getPublishersList()).thenReturn(new DescribableList<Publisher, Descriptor<Publisher>>(project));
         when(buildAction.getPerformanceReportMap()).thenReturn(reportMap);
         when(reportMap.getPerformanceReport(FILENAME)).thenReturn(report);
         when(report.getUriReportMap()).thenReturn(uriReportMap);
 
-        final TestSuiteReportDetail reportDetail = new TestSuiteReportDetail(mock(Project.class), FILENAME, alwaysInRangeMock());
+        final TestSuiteReportDetail reportDetail = new TestSuiteReportDetail(project, FILENAME, alwaysInRangeMock());
         final CategoryDataset dataset = reportDetail.getChartDatasetBuilderForBuilds(TEST_URI, RunList.fromRuns(Collections.singletonList(run))).build();
         assertEquals(dataset.getValue(TEST_URI, new ChartUtil.NumberOnlyBuildLabel((Run<?, ?>) run)), new Long(550L));
     }

--- a/src/test/java/hudson/plugins/performance/parsers/JMeterTestHelper.java
+++ b/src/test/java/hudson/plugins/performance/parsers/JMeterTestHelper.java
@@ -1,0 +1,16 @@
+package hudson.plugins.performance.parsers;
+
+import java.io.File;
+
+import hudson.plugins.performance.reports.PerformanceReport;
+
+/**
+ * Allows tests in other packages to call parse(File)
+ */
+public class JMeterTestHelper {
+
+    public static PerformanceReport parse(String resourceName) throws Exception {
+        File xmlFile = new File(JMeterTestHelper.class.getResource(resourceName).toURI());
+        return new JMeterParser(null).parse(xmlFile);
+    }
+}


### PR DESCRIPTION
Performance reports can be evaluated with the "Use Relative thresholds for build comparison" option. The comparison uses either average, median or percentile response times. Regardless of the choice, the graphs are charted using the average time. 

In my project the average values are pretty crazy due to outliers, but the median values are relatively stable. The comparison is configured to use median values and the tests pass. However, the graphs show averages instead of medians. This is not obvious and causes confusion, because based on the graphs the tests should be failing. 

This PR changes the graphs so that if median/percentile comparison is used, then the graphs will also use median/percentile values. I would be most interested in your comments on 
- whether this functionality makes sense and should be included in the project
- if there is any functionality/configuration options that I missed