### PR TITLE
fix saving RelativeUnstableThresholdNegative

### DIFF
--- a/src/main/java/hudson/plugins/performance/PerformancePublisher.java
+++ b/src/main/java/hudson/plugins/performance/PerformancePublisher.java
@@ -1124,6 +1124,7 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
         this.relativeUnstableThresholdPositive = Math.max(0, Math.min(relativeUnstableThresholdPositive, 100));
     }
 
+    @DataBoundSetter
     public void setRelativeUnstableThresholdNegative(double relativeUnstableThresholdNegative) {
         this.relativeUnstableThresholdNegative = Math.max(0, Math.min(relativeUnstableThresholdNegative, 100));
     }


### PR DESCRIPTION
PR #109 missed one setter when adding @DataBoundSetter annotations. 

Impact: when trying to change "Unstable % Range (-)" in job configuration, then the value is always saved as zero. 