### PR TITLE
add PerformanceProjectAction only to runs, which contain PerformanceBuildAction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,17 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.21</version>
+        <version>2.29</version>
     </parent>
 
     <artifactId>performance</artifactId>
-    <packaging>hpi</packaging>
     <version>3.2-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+
     <name>Performance Plugin</name>
     <description>This plugin allows tracking performance KPIs, based on results read from popular testing tools  (JMeter, JUnit, Taurus).</description>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Performance+Plugin</url>
@@ -26,6 +29,27 @@
         <developerConnection>scm:git:git@github.com:jenkinsci/performance-plugin.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
+
+    <properties>
+        <jenkins.version>1.642.3</jenkins.version>
+        <java.level>7</java.level>
+        <concurrency>2</concurrency>
+        <!-- disable FindBugs temporarily since there are 62 bugs -->
+        <findbugs.failOnError>false</findbugs.failOnError>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
     <dependencies>
         <dependency>
@@ -105,7 +129,6 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
             <version>2.10</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -116,11 +139,24 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.13</version>
+            <version>2.14</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Travis build workaround -->
+                    <argLine>-XX:MaxPermSize=256m -Xmx1024m</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>
@@ -141,46 +177,4 @@
             </build>
         </profile>
     </profiles>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <forkCount>2</forkCount>
-                    <!-- Travis build workaround -->
-                    <argLine>-XX:MaxPermSize=256m -Xmx1024m</argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
-    <properties>
-        <jenkins.version>1.642.3</jenkins.version>
-        <java.level>7</java.level>
-        <!-- disable FindBugs temporarily since there are 62 bugs -->
-        <findbugs.failOnError>false</findbugs.failOnError>
-    </properties>
-
-    <repositories>
-        <repository>
-            <id>jgit-repository</id>
-            <name>Eclipse JGit Repository</name>
-            <url>https://repo.eclipse.org/content/groups/releases/</url>
-        </repository>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
 </project>
-  
-

--- a/src/main/java/hudson/plugins/performance/workflow/WorkflowActionsFactory.java
+++ b/src/main/java/hudson/plugins/performance/workflow/WorkflowActionsFactory.java
@@ -5,13 +5,14 @@ import hudson.Extension;
 import hudson.model.Action;
 import hudson.model.Job;
 import hudson.model.Run;
+import hudson.plugins.performance.actions.PerformanceBuildAction;
 import hudson.plugins.performance.actions.PerformanceProjectAction;
 import jenkins.model.TransientActionFactory;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.Collections;
 
 @Extension
 public class WorkflowActionsFactory extends TransientActionFactory<Job> {
@@ -24,13 +25,12 @@ public class WorkflowActionsFactory extends TransientActionFactory<Job> {
     @Nonnull
     @Override
     public Collection<? extends Action> createFor(@Nonnull Job job) {
-        final List<Action> actions = new LinkedList<>();
-        if (job.getClass().getCanonicalName().startsWith("org.jenkinsci.plugins.workflow")) {
-            final Run<?,?> r = job.getLastSuccessfulBuild();
-            if (r != null) {
-                actions.add(new PerformanceProjectAction(job));
+        if (job instanceof WorkflowJob) {
+            final Run<?, ?> r = job.getLastSuccessfulBuild();
+            if (r != null && !r.getActions(PerformanceBuildAction.class).isEmpty()) {
+                return Collections.singletonList(new PerformanceProjectAction(job));
             }
         }
-        return actions;
+        return Collections.emptyList();
     }
 }

--- a/src/test/java/hudson/plugins/performance/workflow/WorkflowActionsFactoryTest.java
+++ b/src/test/java/hudson/plugins/performance/workflow/WorkflowActionsFactoryTest.java
@@ -5,6 +5,7 @@ import hudson.model.Job;
 import hudson.model.Result;
 import hudson.plugins.performance.actions.PerformanceProjectAction;
 import hudson.slaves.DumbSlave;
+import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -13,18 +14,19 @@ import org.junit.Test;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
+import java.net.URL;
 import java.util.Collection;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class WorkflowActionsFactoryTest {
+    private final WorkflowActionsFactory factory = new WorkflowActionsFactory();
 
     @Rule
     public RestartableJenkinsRule story = new RestartableJenkinsRule();
 
     @Test
     public void testFlow() throws Exception {
-        final WorkflowActionsFactory factory = new WorkflowActionsFactory();
         assertEquals(Job.class, factory.type());
 
         story.addStep(new Statement() {
@@ -34,6 +36,33 @@ public class WorkflowActionsFactoryTest {
                 WorkflowJob p = story.j.createProject(WorkflowJob.class, "demo");
                 p.setDefinition(new CpsFlowDefinition(
                         "node{ echo 'hi, world!' }", true));
+                WorkflowRun r = p.scheduleBuild2(0).waitForStart();
+                story.j.assertBuildStatus(Result.SUCCESS, story.j.waitForCompletion(r));
+                r = p.scheduleBuild2(1).waitForStart();
+                story.j.assertBuildStatus(Result.SUCCESS, story.j.waitForCompletion(r));
+                Collection<? extends Action> actions = factory.createFor(p);
+                assertEquals(0, actions.size());
+            }
+        });
+    }
+
+    @Test
+    public void testFlowWithProjectAction() throws Exception {
+        String fileContents = null;
+
+        URL url = getClass().getResource("/TaurusXMLReport.xml");
+        if (url != null) {
+            fileContents = IOUtils.toString(url);
+        }
+        final String report = fileContents;
+
+        story.addStep(new Statement() {
+            public void evaluate() throws Throwable {
+                DumbSlave s = story.j.createOnlineSlave();
+                s.setLabelString("test performance report DSL function");
+                WorkflowJob p = story.j.createProject(WorkflowJob.class, "demo2");
+                p.setDefinition(new CpsFlowDefinition(
+                        "node{ writeFile file: 'test.xml', text: '''" + report + "'''; perfReport errorFailedThreshold: 2, errorUnstableThreshold: 2, sourceDataFiles: 'test.xml' }", true));
                 WorkflowRun r = p.scheduleBuild2(0).waitForStart();
                 story.j.assertBuildStatus(Result.SUCCESS, story.j.waitForCompletion(r));
                 r = p.scheduleBuild2(1).waitForStart();


### PR DESCRIPTION
The PerformanceProjectAction gets added to every pipeline run. This Performance trend is always empty:
![image](https://user-images.githubusercontent.com/11491375/28066725-62499e0a-663e-11e7-820b-1049c64e18a7.png)

This PR simplifies the WorkflowActionsFactory, so that only runs containing the PerformanceBuildAction are getting the PerformanceProjectAction added.
Furthermore i used 'mvn tidy:pom' to sort the pom.xml and increment some workflow dependencies.