### PR TITLE
Implement fixed-size column width logging of relative comparison results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ script: "mvn -Djava.awt.headless=true -Dmaven.test.redirectTestOutputToFile=true
 after_success:
 - cobertura:dump-datafile
 - bash <(curl -s https://codecov.io/bash)
+dist: precise

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,3 @@ script: "mvn -Djava.awt.headless=true -Dmaven.test.redirectTestOutputToFile=true
 after_success:
 - cobertura:dump-datafile
 - bash <(curl -s https://codecov.io/bash)
-dist: precise


### PR DESCRIPTION
This fixes the garbled console output the Publisher produces for Relative Threshold comparison in Standard Mode