### PR TITLE
Add summary table of failed constraints for Publisher log in expert mode

### DIFF
--- a/src/main/java/hudson/plugins/performance/reports/ConstraintReport.java
+++ b/src/main/java/hudson/plugins/performance/reports/ConstraintReport.java
@@ -238,7 +238,9 @@ public class ConstraintReport {
         if (violatedConstraints == 0)
             return;
 
-        int maxUriColumnWidth = 8, maxReportColumnWidth = 6; // header column widths
+        int maxUriColumnWidth = 8; // header column widths
+        int maxReportColumnWidth = 6;
+
         for (ConstraintEvaluation ce : ceList) {
             AbstractConstraint c = ce.getAbstractConstraint();
             maxUriColumnWidth = Math.max(c.isSpecifiedTestCase() ? c.getTestCaseBlock().getTestCase().length() : 0, maxUriColumnWidth);

--- a/src/test/java/hudson/plugins/performance/reports/ConstraintReportTest.java
+++ b/src/test/java/hudson/plugins/performance/reports/ConstraintReportTest.java
@@ -17,6 +17,8 @@ import hudson.plugins.performance.constraints.RelativeConstraint;
 import hudson.plugins.performance.reports.ConstraintReport;
 import jenkins.model.Jenkins;
 import hudson.plugins.performance.constraints.AbstractConstraint.Escalation;
+import hudson.plugins.performance.constraints.AbstractConstraint.Metric;
+import hudson.plugins.performance.constraints.AbstractConstraint.Operator;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -139,6 +141,27 @@ public class ConstraintReportTest {
         when(ac3.getResultMessage()).thenReturn(resultMsgAc3);
         when(ac4.getResultMessage()).thenReturn(resultMsgAc4);
         when(ac5.getResultMessage()).thenReturn(resultMsgAc5);
+
+        when(rc0.getRelatedPerfReport()).thenReturn("Result.xml");
+        when(rc1.getRelatedPerfReport()).thenReturn("Result.xml");
+        when(rc2.getRelatedPerfReport()).thenReturn("Result.xml");
+        when(ac3.getRelatedPerfReport()).thenReturn("Result.xml");
+        when(ac4.getRelatedPerfReport()).thenReturn("Result.xml");
+        when(ac5.getRelatedPerfReport()).thenReturn("Result.xml");
+
+        when(rc0.getOperator()).thenReturn(Operator.NOT_GREATER);
+        when(rc1.getOperator()).thenReturn(Operator.NOT_LESS);
+        when(rc2.getOperator()).thenReturn(Operator.NOT_GREATER);
+        when(ac3.getOperator()).thenReturn(Operator.NOT_GREATER);
+        when(ac4.getOperator()).thenReturn(Operator.NOT_LESS);
+        when(ac5.getOperator()).thenReturn(Operator.NOT_EQUAL);
+
+        when(rc0.getMeteredValue()).thenReturn(Metric.AVERAGE);
+        when(rc1.getMeteredValue()).thenReturn(Metric.AVERAGE);
+        when(rc2.getMeteredValue()).thenReturn(Metric.MAXIMUM);
+        when(ac3.getMeteredValue()).thenReturn(Metric.AVERAGE);
+        when(ac4.getMeteredValue()).thenReturn(Metric.AVERAGE);
+        when(ac5.getMeteredValue()).thenReturn(Metric.AVERAGE);
 
         when(globBuild.getNumber()).thenReturn(42);
         when(globBuild.getTimestamp()).thenReturn(calendar);


### PR DESCRIPTION
When there's more than just a few constraints, the Publisher log output in expert mode gets cluttered with successful constraint evaluation details.
An additional summary table makes the failing ones more obvious, for example:
```
Summary of failed constraints:
Report     Testcase   Metric     Operator                  Value Level
result.csv *          90% Line   not be greater than     10.000% Error
result.csv login      Average    not be greater than        3000 Warning    
```