### PR TITLE
Add option to write a JUnit report file to the job's workspace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ jdk:
 install:
 - pip install bzt --user
 - "mvn -Dmaven.test.skip=true clean install --batch-mode"
-script: "mvn -Djava.awt.headless=true -Dmaven.test.redirectTestOutputToFile=true -Dcobertura.report.format=xml --fail-at-end --batch-mode cobertura:cobertura"
+script: "mvn -Djava.awt.headless=true -Dmaven.test.redirectTestOutputToFile=true -Dcobertura.report.format=xml --fail-at-end --batch-mode cobertura:cobertura test"
 after_success:
 - cobertura:dump-datafile
 - bash <(curl -s https://codecov.io/bash)
-dist: precise
+sudo: required
+dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
 install:
 - pip install bzt --user
 - "mvn -Dmaven.test.skip=true clean install --batch-mode"
-script: "mvn -Djava.awt.headless=true -Dmaven.test.redirectTestOutputToFile=true -Dcobertura.report.format=xml --fail-at-end --batch-mode cobertura:cobertura test"
+script: "mvn -Djava.awt.headless=true -Dmaven.test.redirectTestOutputToFile=true -Dcobertura.report.format=xml --fail-at-end --batch-mode cobertura:cobertura"
 after_success:
 - cobertura:dump-datafile
 - bash <(curl -s https://codecov.io/bash)

--- a/src/main/java/hudson/plugins/performance/constraints/AbsoluteConstraint.java
+++ b/src/main/java/hudson/plugins/performance/constraints/AbsoluteConstraint.java
@@ -136,6 +136,15 @@ public class AbsoluteConstraint extends AbstractConstraint {
             setResultMessage("Absolute constraint failed! - Report: " + getRelatedPerfReport() + " \n" + "The constraint says: " + getMeteredValue() + " of " + measuredLevel + " must "
                     + getOperator().text + " " + getValue() + "\n" + "Measured value for " + getMeteredValue() + ": " + newValue + "\n" + "Escalation Level: " + getEscalationLevel());
         }
+
+        String unit = getMeteredValue()==Metric.ERRORPRC ? "percent" : "milliseconds";
+        setJunitResult(String.format("<testcase classname=\"%s\" name=\"%s of %s must %s %d %s\">\n", 
+            getRelatedPerfReport(), getMeteredValue(), measuredLevel, getOperator().text, getValue(), unit)
+            + (getSuccess() ? "" :
+                String.format("    <failure type=\"%s\">Measured value for %s: %.0f %s</failure>\n",
+                getEscalationLevel(), getMeteredValue(), newValue, unit))
+            + "</testcase>\n");
+
         return evaluation;
     }
 

--- a/src/main/java/hudson/plugins/performance/constraints/AbstractConstraint.java
+++ b/src/main/java/hudson/plugins/performance/constraints/AbstractConstraint.java
@@ -50,6 +50,10 @@ public abstract class AbstractConstraint implements Describable<AbstractConstrai
      */
     private String resultMessage = "";
     /**
+     * Holds relevant information about the evaluation in Junit format
+     */
+    private String junitResult = "";
+    /**
      * The report file the constraint refers to
      */
     private String relatedPerfReport;
@@ -298,6 +302,14 @@ public abstract class AbstractConstraint implements Describable<AbstractConstrai
 
     public void setResultMessage(String resultMessage) {
         this.resultMessage = resultMessage;
+    }
+
+    public String getJunitResult() {
+        return junitResult;
+    }
+
+    public void setJunitResult(String junitResult) {
+        this.junitResult = junitResult;
     }
 
     public String getRelatedPerfReport() {

--- a/src/main/java/hudson/plugins/performance/constraints/RelativeConstraint.java
+++ b/src/main/java/hudson/plugins/performance/constraints/RelativeConstraint.java
@@ -348,6 +348,15 @@ public class RelativeConstraint extends AbstractConstraint {
                     + getOperator().text + " " + result + "\n" + "Measured value for " + getMeteredValue() + ": " + newValue + "\n" + "Included builds: Last " + getPreviousResults() + " builds \n"
                     + "Escalation Level: " + getEscalationLevel());
         }
+
+        String unit = getMeteredValue()==Metric.ERRORPRC ? "percent" : "milliseconds";
+        setJunitResult(String.format("<testcase classname=\"%s\" name=\"%s of %s must %s %.3f percent above/below previous\">\n",
+            getRelatedPerfReport(), getMeteredValue(), measuredLevel, getOperator().text, getTolerance())
+            + (getSuccess() ? "" :
+                String.format("    <failure type=\"%s\">Measured value for %s: %.0f %s. Previous value: %.0f</failure>\n",
+                getEscalationLevel(), getMeteredValue(), newValue, unit, result))
+            + "</testcase>\n");
+
         return evaluation;
     }
 

--- a/src/main/java/hudson/plugins/performance/reports/ConstraintReport.java
+++ b/src/main/java/hudson/plugins/performance/reports/ConstraintReport.java
@@ -91,6 +91,10 @@ public class ConstraintReport {
      * Logger message for log file and environment variable
      */
     private String loggerMsgAdv;
+    /**
+     * Buld result in JUnit report format
+     */
+    private String junitReport;
 
     public ConstraintReport(ArrayList<ConstraintEvaluation> ceList, Run<?, ?> globBuild, boolean persistConstraintLog) throws IOException, InterruptedException {
         this.newBuild = globBuild;
@@ -101,6 +105,7 @@ public class ConstraintReport {
         if (persistConstraintLog) {
             this.writeResultsToFile();
         }
+        this.junitReport = this.createJunitReport(ceList);
     }
 
     /**
@@ -279,6 +284,21 @@ public class ConstraintReport {
     }
 
     /**
+     * Generate JUnit XML output format for all evaluated constraints. 
+     * Depends on results from previous createMetaData call.
+     */
+    private String createJunitReport(ArrayList<ConstraintEvaluation> ceList) {
+        StringBuffer sb = new StringBuffer();
+        sb.append("<testsuite tests=\""+getAllConstraints()+"\" failures=\""+getViolatedConstraints()+"\" >\n");
+        for (ConstraintEvaluation ce : ceList) {
+            AbstractConstraint c = ce.getAbstractConstraint();
+            sb.append(c.getJunitResult());
+        }
+        sb.append("</testsuite>"); 
+        return sb.toString();
+    }
+
+    /**
      * Creates the log file if not present and writes the report to the log file. Only executed if
      * persistConstraintLog == true
      *
@@ -364,6 +384,10 @@ public class ConstraintReport {
 
     public String getLoggerMsgAdv() {
         return loggerMsgAdv;
+    }
+
+    public String getJunitReport() {
+        return junitReport;
     }
 
     public File getPerformanceLog() {

--- a/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.jelly
@@ -192,7 +192,11 @@
       </tbody>
     </table>
   </f:entry>
-   
+
+  <f:entry title="${%JUnit output file}">
+    <f:textbox name="junitOutput" field="junitOutput" default=""/>
+  </f:entry>
+  
   <f:entry title="Constraints" field="constraints">
     <f:hetero-list name="constraints" hasHeader="true"
                    descriptors="${descriptor.getConstraintDescriptors()}"

--- a/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.properties
+++ b/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.properties
@@ -11,3 +11,5 @@ Thresholds=Thresholds
 Unstable=Unstable
 Failed=Failed
 Source\ files=Source data files (autodetects format):
+
+JUnit\ output\ file=JUnit output file (optional)

--- a/src/test/java/hudson/plugins/performance/constraints/ConstraintCheckerTest.java
+++ b/src/test/java/hudson/plugins/performance/constraints/ConstraintCheckerTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -670,5 +671,33 @@ public class ConstraintCheckerTest {
         checker.setBuilds(list);
 
         assertEquals(list, checker.getBuilds());
+    }
+
+    @Test
+    public void generateJunitOutput() throws Exception {
+        List<AbstractConstraint> constraints = new ArrayList<AbstractConstraint>();
+        constraints.add(rc0);
+        constraints.add(rc1);
+        constraints.add(rc2);
+        constraints.add(ac3);
+        constraints.add(ac4);
+        constraints.add(ac5);
+
+        ArrayList<ConstraintEvaluation> result = new ArrayList<ConstraintEvaluation>();
+        result = constraintChecker.checkAllConstraints(constraints);
+        
+        List<String> expectedList = Arrays.asList(
+            "<testcase classname=\"testResult0.xml\" name=\"Average of testUri0 must not be greater than 10.000 percent above/below previous\">\n</testcase>\n",
+            "<testcase classname=\"testResult0.xml\" name=\"Error % of testUri1 must not be greater than 10.000 percent above/below previous\">\n</testcase>\n",
+            "<testcase classname=\"testResult0.xml\" name=\"90% Line of testUri0 must not be greater than 10.000 percent above/below previous\">\n</testcase>\n",
+            "<testcase classname=\"testResult1.xml\" name=\"Maximum of testUri1 must not be greater than 100 milliseconds\">\n</testcase>\n",
+            "<testcase classname=\"testResult1.xml\" name=\"Median of all test cases must not be equal to 100 milliseconds\">\n</testcase>\n",
+            "<testcase classname=\"testResult1.xml\" name=\"Minimum of all test cases must not be less than 100 milliseconds\">\n    <failure type=\"Error\">Measured value for Minimum: 10 milliseconds</failure>\n</testcase>\n"
+        );
+
+        Iterator<String> expected = expectedList.iterator();
+        for (ConstraintEvaluation ce : result) {
+            assertEquals(expected.next(), ce.getAbstractConstraint().getJunitResult());
+        }
     }
 }

--- a/src/test/java/hudson/plugins/performance/reports/ConstraintReportTest.java
+++ b/src/test/java/hudson/plugins/performance/reports/ConstraintReportTest.java
@@ -228,6 +228,8 @@ public class ConstraintReportTest {
         f.delete();
         f.getParentFile().delete();
         f.getParentFile().getParentFile().delete();
+
+        assertTrue(result.getJunitReport().contains("<testsuite tests=\"6\" failures=\"3\" >"));
     }
 
 }


### PR DESCRIPTION
The console log output becomes cluttered especially when there are a lot of Constraints. 
As each evaluated Constraint can be interpreted as a test case, it is appropriate to report the outcome in JUnit format which can then be processed via existing Jenkins functionality, e.g. `junit` post-build action, test results on dashboards including trends etc.