### PR TITLE
[JENKINS-47808] Fix OutOfMemoryException when parsing huge JMeter XML result file

### DIFF
--- a/src/main/java/hudson/plugins/performance/parsers/ParserDetector.java
+++ b/src/main/java/hudson/plugins/performance/parsers/ParserDetector.java
@@ -14,10 +14,14 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import com.google.common.annotations.VisibleForTesting;
 
 /**
  * Auto-detect parser for file
@@ -131,10 +135,19 @@ public class ParserDetector {
      *  <FinalStatus> - TAURUS.
      */
     private static String detectXMLFileType(String reportPath) throws IOException {
+        try (InputStream in = new FileInputStream(reportPath)) {
+            return detectXMLFileType(in);
+        } catch (Exception ex) {
+            throw new RuntimeException("XML parsing error: ", ex);
+        }
+    }
+
+    @VisibleForTesting
+    protected static String detectXMLFileType(final InputStream in) throws IOException {
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             DocumentBuilder builder = factory.newDocumentBuilder();
-            Document doc = builder.parse(reportPath);
+            Document doc = builder.parse(in);
             XPathFactory xPathfactory = XPathFactory.newInstance();
             XPath xpath = xPathfactory.newXPath();
             if (docContainsTag(doc, xpath, "testResults")) {

--- a/src/test/java/hudson/plugins/performance/parsers/ParserDetectorTest.java
+++ b/src/test/java/hudson/plugins/performance/parsers/ParserDetectorTest.java
@@ -1,5 +1,11 @@
 package hudson.plugins.performance.parsers;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.nio.charset.StandardCharsets;
+
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
@@ -50,5 +56,37 @@ public class ParserDetectorTest {
     public void testIssue45723() throws Exception {
         String filePath = getClass().getResource("/TEST-JUnitResults-success-failure-error.xml").toURI().getPath();
         assertEquals(JUnitParser.class.getSimpleName(), ParserDetector.detect(filePath));
+    }
+
+    @Issue("JENKINS-47808")
+    @Test
+    public void testIssue() throws Exception {
+        assertEquals(JMeterParser.class.getSimpleName(), ParserDetector.detectXMLFileType(getHugeJMeterInputStream()));
+    }
+
+
+    public static InputStream getHugeJMeterInputStream() {
+        return new SequenceInputStream(getPrefixInputStream(), getInfiniteSampleInputStream());
+    }
+
+    private static ByteArrayInputStream getPrefixInputStream() {
+        return new ByteArrayInputStream("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testResults version=\"1.2\">".getBytes(
+                StandardCharsets.UTF_8));
+    }
+
+    private static InputStream getInfiniteSampleInputStream() {
+        return repeat("<httpSample t=\"289\" lt=\"289\" ts=\"1509447454646\" s=\"true\" lb=\"test\" rc=\"200\" rm=\"OK\" tn=\"test\" dt=\"text\" by=\"1410\"/>".getBytes(
+                StandardCharsets.UTF_8), Integer.MAX_VALUE);
+    }
+
+    public static InputStream repeat(final byte[] sample, final int times) {
+        return new InputStream() {
+            private long pos = 0;
+            private final long total = (long)sample.length * times;
+
+            public int read() throws IOException {
+                return pos < total ? sample[(int)(pos++ % sample.length)] : -1;
+            }
+        };
     }
 }


### PR DESCRIPTION
My try to fix [JENKINS-47808].
The first commit is here to reproduce the bug (with an infinite inputstream to simulate huge XML file).
The second commit fix the bug by using a StAX implementation to detect the XML file type.