### PR TITLE
Add a safeDivide() method and use it where divisions by 0 can occur

### DIFF
--- a/src/main/java/hudson/plugins/performance/PerformancePublisher.java
+++ b/src/main/java/hudson/plugins/performance/PerformancePublisher.java
@@ -46,6 +46,7 @@ import hudson.plugins.performance.reports.ConstraintReport;
 import hudson.plugins.performance.reports.PerformanceReport;
 import hudson.plugins.performance.reports.ThroughputReport;
 import hudson.plugins.performance.reports.UriReport;
+import hudson.plugins.performance.tools.SafeMaths;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
@@ -835,7 +836,7 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
     }
 
     private double calculateDiffInPercents(double value1, double value2) {
-        return Math.round(((value1 * 100) / value2) * 100)  / 100d;
+        return Math.round(SafeMaths.safeDivide(value1 * 100, value2) * 100)  / 100d;
     }
 
     private boolean calculateRelativeFailedThresholdNegative(double relativeDiffPercent) {

--- a/src/main/java/hudson/plugins/performance/constraints/RelativeConstraint.java
+++ b/src/main/java/hudson/plugins/performance/constraints/RelativeConstraint.java
@@ -13,6 +13,7 @@ import hudson.plugins.performance.constraints.blocks.TestCaseBlock;
 import hudson.plugins.performance.descriptors.ConstraintDescriptor;
 import hudson.plugins.performance.reports.PerformanceReport;
 import hudson.plugins.performance.reports.UriReport;
+import hudson.plugins.performance.tools.SafeMaths;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
 import hudson.util.RunList;
@@ -394,7 +395,7 @@ public class RelativeConstraint extends AbstractConstraint {
                     setPreviousResults(getPreviousResults() - 1);
                 }
             }
-            result = tmpResult / counter;
+            result = (long)SafeMaths.safeDivide(tmpResult, counter);
         } else {
 			/*
 			 * If no build was found to analyze return Long.MIN_VALUE. This will cause the

--- a/src/main/java/hudson/plugins/performance/parsers/WrkSummarizerParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/WrkSummarizerParser.java
@@ -4,6 +4,8 @@ import hudson.Extension;
 import hudson.plugins.performance.data.HttpSample;
 import hudson.plugins.performance.descriptors.PerformanceReportParserDescriptor;
 import hudson.plugins.performance.reports.PerformanceReport;
+import hudson.plugins.performance.tools.SafeMaths;
+
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.File;
@@ -202,7 +204,7 @@ public class WrkSummarizerParser extends AbstractParser {
 
         double timeValue = Double.parseDouble(timeValueString);
         double timeInMilliSeconds = timeValue * factor;
-        double timeInReturnFormat = timeInMilliSeconds / tu.getFactor();
+        double timeInReturnFormat = SafeMaths.safeDivide(timeInMilliSeconds, tu.getFactor());
 
         return (int) Math.floor(timeInReturnFormat);
     }

--- a/src/main/java/hudson/plugins/performance/reports/UriReport.java
+++ b/src/main/java/hudson/plugins/performance/reports/UriReport.java
@@ -6,6 +6,7 @@ import hudson.plugins.performance.actions.PerformanceProjectAction;
 import hudson.plugins.performance.data.HttpSample;
 import hudson.plugins.performance.data.TaurusFinalStats;
 import hudson.plugins.performance.details.GraphConfigurationDetail;
+import hudson.plugins.performance.tools.SafeMaths;
 import hudson.util.ChartUtil;
 import org.apache.commons.lang.StringUtils;
 import org.jfree.data.time.FixedMillisecond;
@@ -201,13 +202,13 @@ public class UriReport extends AbstractReport implements Serializable, ModelObje
     }
 
     public double errorPercent() {
-        return Math.round((((double) countErrors()) / samplesCount() * 100) * 1000.0) / 1000.0;
+        return Math.round((SafeMaths.safeDivide((double) countErrors(), samplesCount()) * 100) * 1000.0) / 1000.0;
     }
 
     public long getAverage() {
         if (average == null) {
             int samplesCount = samplesCount();
-            average = (samplesCount == 0) ? 0 : totalDuration / samplesCount;
+            average = (samplesCount == 0) ? 0 : (long)SafeMaths.safeDivide(totalDuration, samplesCount);
         }
         return average;
     }

--- a/src/main/java/hudson/plugins/performance/tools/SafeMaths.java
+++ b/src/main/java/hudson/plugins/performance/tools/SafeMaths.java
@@ -1,0 +1,25 @@
+package hudson.plugins.performance.tools;
+
+public class SafeMaths {
+	public static double safeDivide(double dividend, double divisor) {
+		if (Double.compare(divisor, Double.NaN) == 0) {
+			return Double.NaN;
+		}
+		if (Double.compare(dividend, Double.NaN) == 0) {
+			return Double.NaN;
+		}
+		if (Double.compare(divisor, 0.0) == 0) {
+			if (Double.compare(dividend, 0.0) == -1) {
+				return Double.NEGATIVE_INFINITY;
+			}
+			return Double.POSITIVE_INFINITY;
+		}
+		if (Double.compare(divisor, -0.0) == 0) {
+			if (Double.compare(dividend, -0.0) == 1) {
+				return Double.NEGATIVE_INFINITY;
+			}
+			return Double.POSITIVE_INFINITY;
+		}
+		return dividend / divisor;
+	}
+}

--- a/src/test/java/hudson/plugins/performance/tools/SafeMathsTest.java
+++ b/src/test/java/hudson/plugins/performance/tools/SafeMathsTest.java
@@ -1,0 +1,42 @@
+package hudson.plugins.performance.tools;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SafeMathsTest {
+
+	@Test
+	public void safeDivideDividendIsNaN() {
+		final double expected = Double.NaN;
+		final double actual = SafeMaths.safeDivide(Double.NaN, 10);
+		Assert.assertEquals(actual, expected, 0);
+	}
+
+	@Test
+	public void safeDivideDivisorIsNaN() {
+		final double expected = Double.NaN;
+		final double actual = SafeMaths.safeDivide(10, Double.NaN);
+		Assert.assertEquals(actual, expected, 0);
+	}
+
+	@Test
+	public void safeDivideDivisorIsNullPositivePositive() {
+		final double expected = Double.POSITIVE_INFINITY;
+		final double actual = SafeMaths.safeDivide(10, 0);
+		Assert.assertEquals(actual, expected, 0);
+	}
+
+	@Test
+	public void safeDivideDivisorIsNullNegativePositive() {
+		final double expected = Double.NEGATIVE_INFINITY;
+		final double actual = SafeMaths.safeDivide(-10, 0);
+		Assert.assertEquals(actual, expected, 0);
+	}
+
+	@Test
+	public void safeDivideHappyPath() {
+		final double expected = 2;
+		final double actual = SafeMaths.safeDivide(10, 5);
+		Assert.assertEquals(actual, expected, 0);
+	}
+}


### PR DESCRIPTION
If tests are finishing faster than 1s, we get this stack trace:
```
Performance: Parsing JMeter report file '/data/jenkins/project/jobs/module__task-TR-5539_Performance_test/builds/15/performance-reports/Taurus/stats.xml'.
Performance: Failed to parse file '/data/jenkins/project/jobs/module__task-TR-5539_Performance_test/builds/15/performance-reports/Taurus/stats.xml': / by zero
java.lang.ArithmeticException: / by zero
	at hudson.plugins.performance.reports.PerformanceReport.addSample(PerformanceReport.java:200)
	at hudson.plugins.performance.parsers.TaurusParser.readFromXML(TaurusParser.java:78)
	at hudson.plugins.performance.parsers.TaurusParser.parse(TaurusParser.java:42)
	at hudson.plugins.performance.parsers.AbstractParser.parse(AbstractParser.java:81)
	at hudson.plugins.performance.PerformancePublisher.locatePerformanceReports(PerformancePublisher.java:458)
	at hudson.plugins.performance.PerformancePublisher.prepareEvaluation(PerformancePublisher.java:410)
	at hudson.plugins.performance.PerformancePublisher.perform(PerformancePublisher.java:381)
	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:80)
	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:67)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$1$1.call(SynchronousNonBlockingStepExecution.java:49)
	at hudson.security.ACL.impersonate(ACL.java:290)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$1.run(SynchronousNonBlockingStepExecution.java:46)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
I have added a safeDivide() method and tried to use it where it was relevant.
I also add a log message to inform that tests are finishing too fast.