### PR TITLE
[JENKINS-55787] Switch from table to entry

### DIFF
--- a/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.jelly
@@ -1,9 +1,9 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
-   <f:entry title="${%Source files}" field="sourceDataFiles">
-      <f:textbox />
-   </f:entry>
+  <f:entry title="${%Source files}" field="sourceDataFiles">
+    <f:textbox />
+  </f:entry>
 
    <f:entry title="${%filterRegex}" field="filterRegex">
       <f:textbox />
@@ -14,208 +14,208 @@
   </f:entry> 
 
   <f:entry>
-    <table style="border:1;border-style:solid"> 
+    <table style="border:1;border-style:solid">
       <p><b>Standard Mode</b></p>
-        <f:entry title="Select mode:   ">
-          <f:booleanRadio name="modeOfThreshold" field="modeOfThreshold" true="Relative Threshold" false="Error Threshold" />
+      <f:entry title="Select mode:   ">
+        <f:booleanRadio name="modeOfThreshold" field="modeOfThreshold" true="Relative Threshold" false="Error Threshold" />
+      </f:entry>
+
+      <f:block>
+        <f:entry title="Use Error thresholds on single build:   ">
+          <table width="500px">
+            <tr>
+              <td>
+                <label>${%Unstable}</label>
+              </td>
+              <td>
+                <f:textbox field="errorUnstableThreshold" default="-1"/>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <label>${%Failed}</label>
+              </td>
+              <td>
+                <f:textbox field="errorFailedThreshold" default="-1"/>
+              </td>
+            </tr>
+          </table>
         </f:entry>
 
-  <f:block>
-    <f:entry title="Use Error thresholds on single build:   ">
-      <table width="500px">
-        <tr>
-          <td>
-            <label>${%Unstable}</label>
-          </td>
-          <td>
-            <f:textbox field="errorUnstableThreshold" default="-1"/>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <label>${%Failed}</label>
-          </td>
-          <td>
-            <f:textbox field="errorFailedThreshold" default="-1"/>
-          </td>
-        </tr>
-      </table>
-    </f:entry>
+        <f:advanced>
+          <f:entry title="${%Average response time threshold}" field="errorUnstableResponseTimeThreshold">
+            <table>
+              <tbody>
+                <tr>
+                  <td>
+                    <f:textarea style="width:600px;height:100px;"/>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </f:entry>
+        </f:advanced>
 
-    <f:advanced>
-      <f:entry title="${%Average response time threshold}" field="errorUnstableResponseTimeThreshold">
-        <table>
+        <f:entry title="Use Relative thresholds for build comparison:   ">
+          <table width="500px" cellspacing="5">
+            <tr>
+              <td width="25%">
+                <label> </label>
+              </td>
+              <td width="20%" align="center">
+                <label>(-)</label>
+              </td>
+              <td width="20%" align="center">
+                <label>(+)</label>
+              </td>
+            </tr>
+            <tr>
+              <td width="25%">
+                <label>Unstable % Range</label>
+              </td>
+              <td>
+                <f:number field="relativeUnstableThresholdNegative" default="-1.0"/>
+              </td>
+              <td>
+                <f:number field="relativeUnstableThresholdPositive" default="-1.0"/>
+              </td>
+            </tr>
+            <tr>
+              <td width="25%">
+                <label>Failed % Range</label>
+              </td>
+              <td>
+                <f:number field="relativeFailedThresholdNegative" default="-1.0"/>
+              </td>
+              <td>
+                <f:number field="relativeFailedThresholdPositive" default="-1.0"/>
+              </td>
+            </tr>
+            <tr>
+              <td colspan="3">
+                <table>
+                  <tr>
+                    <td width="85%">
+                      <f:booleanRadio name="compareBuildPrevious" field="compareBuildPrevious" true="Compare with previous Build" false="Compare with Build number" />
+                    </td>
+                    <td width="15%">
+                      <f:number field="nthBuildNumber"/>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td width="25%">
+                <label>${%Compare based on}</label>
+              </td>
+              <td colspan="2">
+                <table>
+                  <tr>
+                    <f:entry field="configType" name="configType">
+                      <f:select name="configType">
+                        <option value="ART">Average Response Time</option>
+                        <option value="MRT">Median Response Time</option>
+                        <option value="PRT">90% ResponseTime</option>
+                      </f:select>
+                    </f:entry>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </f:entry>
+      </f:block>
+    </table>
+  </f:entry>                 
+  
+  <f:entry>
+    <table style="border:1;border-style:solid">
+      <p><b>Expert Mode</b></p>
+      <f:entry title="Constraint settings">
+        <table width="500px">
           <tbody>
             <tr>
               <td>
-                <f:textarea style="width:600px;height:100px;"/>
+                <f:checkbox name="ignoreFailedBuilds" title="Ignore Failed Builds"  checked="${instance.isIgnoreFailedBuilds()}"/>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <f:checkbox name="ignoreUnstableBuilds" title="Ignore Unstable Builds" field="ignoreUnstableBuilds" checked="${instance.isIgnoreUnstableBuilds()}"/>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <f:checkbox name="persistConstraintLog" title="Save constraint log to workspace"  checked="${instance.isPersistConstraintLog()}"/>
               </td>
             </tr>
           </tbody>
         </table>
       </f:entry>
-    </f:advanced>
 
-    <f:entry title="Use Relative thresholds for build comparison:   ">
-      <table width="500px" cellspacing="5">
-        <tr>
-          <td width="25%">
-            <label> </label>
-          </td>
-          <td width="20%" align="center">
-            <label>(-)</label>
-          </td>
-          <td width="20%" align="center">
-            <label>(+)</label>
-          </td>
-        </tr>
-        <tr>
-          <td width="25%">
-            <label>Unstable % Range</label>
-          </td>
-          <td>
-            <f:number field="relativeUnstableThresholdNegative" default="-1.0"/>
-          </td>
-          <td>
-            <f:number field="relativeUnstableThresholdPositive" default="-1.0"/>
-          </td>
-        </tr>
-        <tr>
-          <td width="25%">
-            <label>Failed % Range</label>
-          </td>
-          <td>
-            <f:number field="relativeFailedThresholdNegative" default="-1.0"/>
-          </td>
-          <td>
-            <f:number field="relativeFailedThresholdPositive" default="-1.0"/>
-          </td>
-        </tr>
-        <tr>
-          <td colspan="3">
-            <table>
-              <tr>
-                <td width="85%">
-                  <f:booleanRadio name="compareBuildPrevious" field="compareBuildPrevious" true="Compare with previous Build" false="Compare with Build number" />
-                </td>
-                <td width="15%">
-                  <f:number field="nthBuildNumber"/>
-                </td>
-              </tr>
-            </table>
-          </td>
-        </tr>
-        <tr>
-          <td width="25%">
-            <label>${%Compare based on}</label>
-          </td>
-          <td colspan="2">
-            <table>
-              <tr>
-                <f:entry field="configType" name="configType">
-                  <f:select name="configType">
-                    <option value="ART">Average Response Time</option>
-                    <option value="MRT">Median Response Time</option>
-                    <option value="PRT">90% ResponseTime</option>
-                  </f:select>
-                </f:entry>
-              </tr>
-            </table>
-          </td>
-        </tr>
-      </table>
-    </f:entry>
-  </f:block>
-</table>
-</f:entry>                 
-  
-<f:entry>
- <table style="border:1;border-style:solid">
-   <p><b>Expert Mode</b></p>
-   <f:entry title="Constraint settings">
-    <table width="500px">
-      <tbody>
-        <tr>
-          <td>
-          <f:checkbox name="ignoreFailedBuilds" title="Ignore Failed Builds"  checked="${instance.isIgnoreFailedBuilds()}"/>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <f:checkbox name="ignoreUnstableBuilds" title="Ignore Unstable Builds" field="ignoreUnstableBuilds" checked="${instance.isIgnoreUnstableBuilds()}"/>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <f:checkbox name="persistConstraintLog" title="Save constraint log to workspace"  checked="${instance.isPersistConstraintLog()}"/>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </f:entry>
-
-  <f:entry title="${%JUnit output file}">
-    <f:textbox name="junitOutput" field="junitOutput" default=""/>
-  </f:entry>
+      <f:entry title="${%JUnit output file}">
+        <f:textbox name="junitOutput" field="junitOutput" default=""/>
+      </f:entry>
   
   <f:entry title="Constraints" field="constraints">
     <f:hetero-list name="constraints" hasHeader="true"
                    descriptors="${descriptor.getConstraintDescriptors()}"
                    items="${instance.constraints}"
                    addCaption="${%Add a new constraint}"/>
-   </f:entry>
-  </table>
- </f:entry>
+      </f:entry>
+    </table>
+  </f:entry>
 
-    <f:advanced>
-        <f:entry field="graphType" name="graphType" title="Select graphed metric">
-            <f:select name="graphType">
-                <option value="ART">Average Response Time</option>
-                <option value="MRT">Median Response Time</option>
-                <option value="PRT">90% Response Time</option>
-            </f:select>
-        </f:entry>
+  <f:advanced>
+    <f:entry field="graphType" name="graphType" title="Select graphed metric">
+      <f:select name="graphType">
+        <option value="ART">Average Response Time</option>
+        <option value="MRT">Median Response Time</option>
+        <option value="PRT">90% Response Time</option>
+      </f:select>
+    </f:entry>
 
-        <f:entry title="Select display percentiles">
-            <f:textbox name="percentiles" field="percentiles" default="0,50,90,100"/>
-        </f:entry>
+    <f:entry title="Select display percentiles">
+      <f:textbox name="percentiles" field="percentiles" default="0,50,90,100"/>
+    </f:entry>
 
-        <f:entry title="${%Performance display}">
-            <table>
-                <tbody>
-                    <tr>
-                        <td>
-                            <f:checkbox name="modePerformancePerTestCase" title="Display Performance Report Per Test Case" field="modePerformancePerTestCase">
-                                Display Performance Report Per Test Case
-                            </f:checkbox>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <f:checkbox name="modeThroughput" title="Display Performance Report with Throughput (requests per second)" field="modeThroughput">
-                                Display Performance Report with Throughput (requests per second)
-                            </f:checkbox>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <f:checkbox name="excludeResponseTime" title="Exclude response time of errored samples" field="excludeResponseTime">
-                                Exclude response time of errored samples
-                            </f:checkbox>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <f:checkbox name="failBuildIfNoResultFile" title="Fail build when result files are not present" default="true" field="failBuildIfNoResultFile">
-                                Fail build when result files are not present
-                            </f:checkbox>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </f:entry>
-        <f:entry title="Baseline build number">
-            <f:number name="baselineBuild" field="baselineBuild" />
-        </f:entry>
-    </f:advanced>
+    <f:entry title="${%Performance display}">
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              <f:checkbox name="modePerformancePerTestCase" title="Display Performance Report Per Test Case" field="modePerformancePerTestCase">
+                Display Performance Report Per Test Case
+              </f:checkbox>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <f:checkbox name="modeThroughput" title="Display Performance Report with Throughput (requests per second)" field="modeThroughput">
+                Display Performance Report with Throughput (requests per second)
+              </f:checkbox>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <f:checkbox name="excludeResponseTime" title="Exclude response time of errored samples" field="excludeResponseTime">
+                Exclude response time of errored samples
+              </f:checkbox>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <f:checkbox name="failBuildIfNoResultFile" title="Fail build when result files are not present" default="true" field="failBuildIfNoResultFile">
+                Fail build when result files are not present
+              </f:checkbox>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </f:entry>
+    <f:entry title="Baseline build number">
+      <f:number name="baselineBuild" field="baselineBuild" />
+    </f:entry>
+  </f:advanced>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/performance/build/PerformanceTestBuild/config.jelly
+++ b/src/main/resources/hudson/plugins/performance/build/PerformanceTestBuild/config.jelly
@@ -12,11 +12,21 @@
             <f:textbox />
         </f:entry>
         <f:entry>
-            <f:optionalBlock field="alwaysUseVirtualenv" title="${%Use virtualenv}" />
-            <f:optionalBlock field="generatePerformanceTrend" checked="true" title="${%Auto report}" />
-            <f:optionalBlock field="useBztExitCode" checked="true" title="${%Use bzt code}" />
-            <f:optionalBlock field="printDebugOutput" title="${%Debug mode}" />
-            <f:optionalBlock field="useSystemSitePackages"  checked="true" title="${%Virtualenv option}" />
+            <f:entry>
+                <f:checkbox field="alwaysUseVirtualenv" title="${%Use virtualenv}" />
+            </f:entry>
+            <f:entry>
+                <f:checkbox field="generatePerformanceTrend" checked="true" title="${%Auto report}" />
+            </f:entry>
+            <f:entry>
+                <f:checkbox field="useBztExitCode" checked="true" title="${%Use bzt code}" />
+            </f:entry>
+            <f:entry>
+                <f:checkbox field="printDebugOutput" title="${%Debug mode}" />
+            </f:entry>
+            <f:entry>
+                <f:checkbox field="useSystemSitePackages"  checked="true" title="${%Virtualenv option}" />
+            </f:entry>
         </f:entry>
     </f:advanced>
 </j:jelly>


### PR DESCRIPTION
Sorry, turns out that data migration doesn't like what I did in #182

[https://issues.jenkins-ci.org/browse/JENKINS-55787](https://issues.jenkins-ci.org/browse/JENKINS-55787)

Basically checkboxes should have labels, splitting the labels away from their checkboxes is poor UX, poor accessibility. This change brings the layout more inline with how normal settings UIs lay out checkboxes.