### PR TITLE
Fix ineffective report cache

### DIFF
--- a/src/main/java/hudson/plugins/performance/parsers/AbstractParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/AbstractParser.java
@@ -135,8 +135,8 @@ public abstract class AbstractParser extends PerformanceReportParser {
                 try (FileInputStream fis = new FileInputStream(serialized);
                         BufferedInputStream bis = new BufferedInputStream(fis);
                         ObjectInputStream in = new ObjectInputStreamWithClassMapping(bis)) {
-                        report = (PerformanceReport) in.readObject();
-                        CACHE.put(serialized, report);
+                    report = (PerformanceReport) in.readObject();
+                    CACHE.put(serialized, report);
                     return report;
                 } catch (FileNotFoundException ex) {
                     // That's OK
@@ -144,7 +144,7 @@ public abstract class AbstractParser extends PerformanceReportParser {
                     LOGGER.log(Level.WARNING, "Reading serialized PerformanceReport instance from file '" + serialized + "' failed.", ex);
                 }
             }
-            return null;
+            return report;
         }
     }
 

--- a/src/test/java/hudson/plugins/performance/parsers/AbstractParserTest.java
+++ b/src/test/java/hudson/plugins/performance/parsers/AbstractParserTest.java
@@ -14,12 +14,14 @@ public class AbstractParserTest {
     public void testDeserialized() throws Exception {
         File serializedFile = new File(getClass().getResource("/results.v.2.0.jtl.serialized").toURI());
         String reportFilePath = serializedFile.getAbsolutePath().replace(".serialized", "");
-        PerformanceReport report = AbstractParser.loadSerializedReport(new File(reportFilePath));
+        File reportFile = new File(reportFilePath);
+        PerformanceReport report = AbstractParser.loadSerializedReport(reportFile);
+        assertNotNull(report);
+        report = AbstractParser.loadSerializedReport(reportFile); // subsequent calls should be cached
         assertNotNull(report);
         assertEquals("totalDuration", 2030.47, report.getTotalTrafficInKb(), 0.001);
         assertEquals("samples count", 200, report.samplesCount());
     }
-
 
     @Test
     public void testUploadOldReport() throws Exception {


### PR DESCRIPTION
A bug in `AbstractParser.loadSerializedReport` makes the report caching ineffective and leads to parsing for previously cached reports:
https://github.com/jenkinsci/performance-plugin/blob/performance-3.16/src/main/java/hudson/plugins/performance/parsers/AbstractParser.java#L147
```
            PerformanceReport report = CACHE.getIfPresent(serialized);
            if (report == null && file.exists() && file.canRead()) {
                // deserialize...
            }
            return null; // THIS WILL CAUSE THE CALLER TO RE-PARSE
```