### PR TITLE
Add baseline comparison option for Relative Constraint

### DIFF
--- a/src/main/java/hudson/plugins/performance/PerformancePublisher.java
+++ b/src/main/java/hudson/plugins/performance/PerformancePublisher.java
@@ -1025,7 +1025,7 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
         PrintStream logger = listener.getLogger();
         ConstraintFactory factory = new ConstraintFactory();
         ConstraintSettings settings = new ConstraintSettings(listener, ignoreFailedBuilds, ignoreUnstableBuilds,
-                persistConstraintLog);
+                persistConstraintLog, getBaselineBuild());
         ConstraintChecker checker = new ConstraintChecker(settings, run.getParent().getBuilds());
         ArrayList<ConstraintEvaluation> ceList = new ArrayList<>();
         try {

--- a/src/main/java/hudson/plugins/performance/constraints/AbstractConstraint.java
+++ b/src/main/java/hudson/plugins/performance/constraints/AbstractConstraint.java
@@ -200,7 +200,7 @@ public abstract class AbstractConstraint implements Describable<AbstractConstrai
             if (rc.getTimeframeStart().after(rc.getTimeframeEnd())) {
                 throw new AbortException("Performance Plugin: The start date of a Relative Constraint can't be after the end date");
             }
-            if (!rc.getPreviousResultsBlock().isChoicePreviousResults()) {
+            if (rc.getPreviousResultsBlock().isChoiceTimeframe()) {
                 final SimpleDateFormat dfLong = new SimpleDateFormat("yyyy-MM-dd HH:mm");
                 try {
                     rc.setTimeframeStart(dfLong.parse(rc.getTimeframeStartString()));

--- a/src/main/java/hudson/plugins/performance/constraints/blocks/PreviousResultsBlock.java
+++ b/src/main/java/hudson/plugins/performance/constraints/blocks/PreviousResultsBlock.java
@@ -16,8 +16,11 @@ public class PreviousResultsBlock extends AbstractDescribableImpl<PreviousResult
     /**
      * True: relative constraint includes a user defined number of builds into the evaluation False:
      * relative constraint includes all builds that have taken place in an user defined time frame
+     * BASELINE: relative constraint includes baseline build defined in the PerformancePublisher settings.
+     * True and false are retained for backward compatibility.
      */
-    private boolean choicePreviousResults;
+    public static final String PREVIOUS = "true", TIMEFRAME = "false", BASELINE = "BASELINE";
+    private String choicePreviousResults = TIMEFRAME; // keep field name for backward compatibility
     /**
      * Holds the user defined number of builds which are to include to the evaluation
      */
@@ -42,27 +45,35 @@ public class PreviousResultsBlock extends AbstractDescribableImpl<PreviousResult
 
     @DataBoundConstructor
     public PreviousResultsBlock(String value, String previousResultsString, String timeframeStartString, String timeframeEndString) {
-        this.setChoicePreviousResults(Boolean.parseBoolean(value));
+        this.setValue(value);
         this.previousResultsString = previousResultsString;
         this.timeframeStartString = timeframeStartString;
         this.timeframeEndString = timeframeEndString;
     }
 
     public boolean isChoicePreviousResults() {
-        return choicePreviousResults;
+        return PREVIOUS.equals(choicePreviousResults);
     }
 
     public void setChoicePreviousResults(boolean choicePreviousResults) {
-        this.choicePreviousResults = choicePreviousResults;
+        this.choicePreviousResults = choicePreviousResults ? PREVIOUS : TIMEFRAME; // backward compatibility
+    }
+
+    public boolean isChoiceTimeframe() {
+        return TIMEFRAME.equals(choicePreviousResults);
+    }
+
+    public boolean isChoiceBaselineBuild() {
+        return BASELINE.equals(choicePreviousResults);
     }
 
     // Workaround for radioBlock sending 'value' instead of field name (JENKINS-45988):
     public String getValue() {
-        return Boolean.toString(isChoicePreviousResults());
+        return choicePreviousResults;
     }
 
     public void setValue(String value) {
-        setChoicePreviousResults(Boolean.parseBoolean(value));
+        this.choicePreviousResults = value;
     }
 
     public String getPreviousResultsString() {

--- a/src/main/java/hudson/plugins/performance/data/ConstraintSettings.java
+++ b/src/main/java/hudson/plugins/performance/data/ConstraintSettings.java
@@ -29,11 +29,18 @@ public class ConstraintSettings {
      */
     private boolean persistConstraintLog;
 
-    public ConstraintSettings(TaskListener listener, boolean ignoreFailedBuilds, boolean ignoreUnstableBuilds, boolean persistConstraintLog) {
+    /**
+     * Relative constraints may need access to globally configured baseline build number to evaluate against
+     */
+    private int baselineBuild;
+
+    public ConstraintSettings(TaskListener listener, boolean ignoreFailedBuilds, boolean ignoreUnstableBuilds, boolean persistConstraintLog,
+                              int baselineBuild) {
         this.setListener(listener);
         this.setIgnoreFailedBuilds(ignoreFailedBuilds);
         this.setIgnoreUnstableBuilds(ignoreUnstableBuilds);
         this.setPersistConstraintLog(persistConstraintLog);
+        this.setBaselineBuild(baselineBuild);
     }
 
     public TaskListener getListener() {
@@ -66,5 +73,13 @@ public class ConstraintSettings {
 
     public void setPersistConstraintLog(boolean persistConstraintLog) {
         this.persistConstraintLog = persistConstraintLog;
+    }
+
+    public int getBaselineBuild() {
+        return baselineBuild;
+    }
+
+    public void setBaselineBuild(int baselineBuild) {
+        this.baselineBuild = baselineBuild;
     }
 }

--- a/src/main/resources/hudson/plugins/performance/constraints/RelativeConstraint/config.jelly
+++ b/src/main/resources/hudson/plugins/performance/constraints/RelativeConstraint/config.jelly
@@ -110,7 +110,7 @@
           	<table>
           		<tr>
           			<td>
-            			<f:radioBlock name="${radioId}.previousResultsBlock" field="previousResultsBlock" value="false" title="Compare with Builds within a timeframe" checked="${!instance.getPreviousResultsBlock().isChoicePreviousResults()}">
+            			<f:radioBlock name="${radioId}.previousResultsBlock" field="previousResultsBlock" value="false" title="Compare with Builds within a timeframe" checked="${instance.getPreviousResultsBlock().isChoiceTimeframe()}">
 						<f:entry>
             				<table cellspacing="5">
             					<tr>
@@ -138,7 +138,19 @@
             	</tr>  	
             </table>
           </td>
-        </tr>	
+        </tr>
+        <tr>
+          <td colspan="4">
+        	<table>
+          		<tr>
+          			<td>
+            			<f:radioBlock name="${radioId}.previousResultsBlock" field="previousResultsBlock" value="BASELINE" title="Compare with baseline build" checked="${instance.getPreviousResultsBlock().isChoiceBaselineBuild()}">
+           				</f:radioBlock>
+            		</td>
+            	</tr>
+            </table>
+          </td>
+        </tr>
       </table>
      </f:entry>
 		

--- a/src/test/java/hudson/plugins/performance/constraints/ConstraintCheckerTest.java
+++ b/src/test/java/hudson/plugins/performance/constraints/ConstraintCheckerTest.java
@@ -50,7 +50,7 @@ public class ConstraintCheckerTest {
     ConstraintChecker constraintChecker = new ConstraintChecker(null, null);
 
     @InjectMocks
-    ConstraintSettings constraintSettings = new ConstraintSettings(null, false, false, false);
+    ConstraintSettings constraintSettings = new ConstraintSettings(null, false, false, false, 0);
 
     @Mock
     Jenkins jenkins;
@@ -172,12 +172,14 @@ public class ConstraintCheckerTest {
     PreviousResultsBlock rb3;
     PreviousResultsBlock rb4;
     PreviousResultsBlock rb5;
+    PreviousResultsBlock rb6;
     RelativeConstraint rc0;
     RelativeConstraint rc1;
     RelativeConstraint rc2;
     RelativeConstraint rc3;
     RelativeConstraint rc4;
     RelativeConstraint rc5;
+    RelativeConstraint rc6;
 
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
@@ -241,21 +243,24 @@ public class ConstraintCheckerTest {
         constraints.add(rc3);
         constraints.add(rc4);
         constraints.add(rc5);
+        constraints.add(rc6);
 
         ArrayList<ConstraintEvaluation> result = new ArrayList<ConstraintEvaluation>();
         result = constraintChecker.checkAllConstraints(constraints);
 
-        assertEquals(6, result.size());
+        assertEquals(7, result.size());
         assertEquals(rc0, result.get(0).getAbstractConstraint());
         assertEquals(rc1, result.get(1).getAbstractConstraint());
         assertEquals(rc2, result.get(2).getAbstractConstraint());
         assertEquals(rc3, result.get(3).getAbstractConstraint());
         assertEquals(rc4, result.get(4).getAbstractConstraint());
         assertEquals(rc5, result.get(5).getAbstractConstraint());
+        assertEquals(rc6, result.get(6).getAbstractConstraint());
 
         assertTrue(result.get(0).getAbstractConstraint().getSuccess());
         assertTrue(result.get(4).getAbstractConstraint().getSuccess());
         assertTrue(result.get(5).getAbstractConstraint().getSuccess());
+        assertTrue(result.get(6).getAbstractConstraint().getSuccess());
 
         assertEquals(11, result.get(0).getConstraintValue(), 0);
         assertEquals(10, result.get(3).getMeasuredValue(), 0);
@@ -302,7 +307,7 @@ public class ConstraintCheckerTest {
         /**
          * Mock behaviour of the builds
          */
-        constraintSettings = new ConstraintSettings(buildListener, true, true, true);
+        constraintSettings = new ConstraintSettings(buildListener, true, true, true, 3);
         when(this.buildListener.getLogger()).thenReturn(printStream);
         constraintChecker = new ConstraintChecker(constraintSettings, abstractBuildsList);
 
@@ -331,6 +336,7 @@ public class ConstraintCheckerTest {
         rb3 = new PreviousResultsBlock("false", "", "2015-01-01", "2015-02-01");
         rb4 = new PreviousResultsBlock("false", "", "2015-01-01 12:00", "2015-02-01");
         rb5 = new PreviousResultsBlock("false", "", "2015-01-01", "now");
+        rb6 = new PreviousResultsBlock("BASELINE", "", "", "");
 
         rc0 = new RelativeConstraint(Metric.AVERAGE, Operator.NOT_GREATER, "testResult0.xml", Escalation.INFORMATION, false,
                 ob0, rb0, 10);
@@ -346,6 +352,8 @@ public class ConstraintCheckerTest {
         rc5 = new RelativeConstraint(Metric.MINIMUM, Operator.NOT_LESS, "testResult1.xml", Escalation.ERROR, false, ob2,
                 rb5, 10);
         rc5.setSpecifiedTestCase(false);
+        rc6 = new RelativeConstraint(Metric.AVERAGE, Operator.NOT_GREATER, "testResult0.xml", Escalation.INFORMATION, false,
+                ob0, rb0, 10); // same as rc0 but against baseline build
 
         abstractBuildsList.add(abstractBuild0);
         abstractBuildsList.add(abstractBuild1);


### PR DESCRIPTION
The Performance Publisher's "Expert Mode" currently has two options for "Relative Constraints":
- Compare with number of previous builds
- Compare with builds within a time frame

However, there is no option to compare with a specific build number (which even the "Standard Mode" can do).

Since the addition of the baseline build setting in #178 for calculating report tables, it would make sense to use the same baseline build for "Relative Constraint" evaluations.

The challenge is not to break existing Jobs and Pipelines, which this PR addresses by leaving existing configuration fields and their existing values unchanged, but changing them to a String field with the same representation, namely in `PreviousResultsBlock`:
```
public static final String PREVIOUS = "true", TIMEFRAME = "false", BASELINE = "BASELINE";
private String choicePreviousResults = TIMEFRAME; // keep field name for backward compatibility
```

This way existing Freestyle config.xml and Pipeline DSL calls keep working by unmarshalling the former Boolean values into Strings.