### PR TITLE
Adding Locust report files parser.

### DIFF
--- a/src/main/java/hudson/plugins/performance/parsers/LocustParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/LocustParser.java
@@ -14,34 +14,28 @@ import java.io.Reader;
 import java.util.Date;
 import java.util.List;
 
-public class LocustParser extends AbstractParser
-{
-    enum ReportColumns
-    {
+public class LocustParser extends AbstractParser {
+    enum ReportColumns {
         Method(0), Name(1), Requests(2), Failures(3), Median(4),
         Average(5), Min(6), Max(7), AvgContentSize(8), Rps(9);
 
         int column;
 
-        ReportColumns(final int order)
-        {
+        ReportColumns(final int order) {
             this.column = order;
         }
 
-        int getColumn()
-        {
+        int getColumn() {
             return column;
         }
     }
 
-    public LocustParser(final String glob, final String percentiles, final String filterRegex)
-    {
+    public LocustParser(final String glob, final String percentiles, final String filterRegex) {
         super(glob, percentiles, filterRegex);
     }
 
     @Override
-    PerformanceReport parse(final File reportFile) throws Exception
-    {
+    PerformanceReport parse(final File reportFile) throws Exception {
         PerformanceReport report = createPerformanceReport();
         report.setReportFileName(reportFile.getName());
         report.setExcludeResponseTime(excludeResponseTime);
@@ -83,8 +77,7 @@ public class LocustParser extends AbstractParser
         return report;
     }
 
-    List<CSVRecord> getCsvData(final File reportFile)
-    {
+    List<CSVRecord> getCsvData(final File reportFile) {
         List<CSVRecord> records = null;
         try (Reader reader = new BufferedReader(new FileReader(reportFile))) {
             CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT.withHeader());
@@ -97,8 +90,7 @@ public class LocustParser extends AbstractParser
     }
 
     @Override
-    public String getDefaultGlobPattern()
-    {
+    public String getDefaultGlobPattern() {
         return "**/*.csv";
     }
 }

--- a/src/main/java/hudson/plugins/performance/parsers/LocustParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/LocustParser.java
@@ -1,0 +1,104 @@
+package hudson.plugins.performance.parsers;
+
+import hudson.plugins.performance.data.HttpSample;
+import hudson.plugins.performance.reports.PerformanceReport;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.Date;
+import java.util.List;
+
+public class LocustParser extends AbstractParser
+{
+    enum ReportColumns
+    {
+        Method(0), Name(1), Requests(2), Failures(3), Median(4),
+        Average(5), Min(6), Max(7), AvgContentSize(8), Rps(9);
+
+        int column;
+
+        ReportColumns(final int order)
+        {
+            this.column = order;
+        }
+
+        int getColumn()
+        {
+            return column;
+        }
+    }
+
+    public LocustParser(final String glob, final String percentiles, final String filterRegex)
+    {
+        super(glob, percentiles, filterRegex);
+    }
+
+    @Override
+    PerformanceReport parse(final File reportFile) throws Exception
+    {
+        PerformanceReport report = createPerformanceReport();
+        report.setReportFileName(reportFile.getName());
+        report.setExcludeResponseTime(excludeResponseTime);
+        List<CSVRecord> reportData = getCsvData(reportFile);
+        final Date now = new Date();
+
+        for (CSVRecord record : reportData) {
+            String name = record.get(ReportColumns.Name.getColumn());
+            long average = Long.parseLong(record.get(ReportColumns.Average.getColumn()));
+            long min = Long.parseLong(record.get(ReportColumns.Min.getColumn()));
+            long max = Long.parseLong(record.get(ReportColumns.Max.getColumn()));
+            long failures = Long.parseLong(record.get(ReportColumns.Failures.getColumn()));
+            long success = Long.parseLong(record.get(ReportColumns.Requests.getColumn()));
+            float errors = new Float(failures / success);
+            long avgContentSize = Long.parseLong(record.get(ReportColumns.AvgContentSize.getColumn()));
+
+            if (name.equals("Total")) {
+                report.setSummarizerSize(reportData.size() - 1);
+                report.setSummarizerAvg(average);
+                report.setSummarizerMin(min);
+                report.setSummarizerMax(max);
+                report.setSummarizerErrors(Float.toString(errors));
+            } else {
+                HttpSample sample = new HttpSample();
+                sample.setSuccessful(failures == 0);
+                sample.setSummarizer(true);
+                sample.setUri(name);
+                sample.setSummarizerMax(max);
+                sample.setSummarizerMin(min);
+                sample.setDuration(average);
+                sample.setSummarizerSamples(success);
+                sample.setSummarizerErrors(errors);
+                sample.setSizeInKb(avgContentSize * success);
+                sample.setDate(now);
+                report.addSample(sample);
+            }
+        }
+
+        return report;
+    }
+
+    List<CSVRecord> getCsvData(final File reportFile)
+    {
+        List<CSVRecord> records = null;
+        try (Reader reader = new BufferedReader(new FileReader(reportFile))) {
+            CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT.withHeader());
+            records = csvParser.getRecords();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return records;
+    }
+
+    @Override
+    public String getDefaultGlobPattern()
+    {
+        return "**/*.csv";
+    }
+}

--- a/src/main/java/hudson/plugins/performance/parsers/ParserDetector.java
+++ b/src/main/java/hudson/plugins/performance/parsers/ParserDetector.java
@@ -6,6 +6,7 @@ import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -48,10 +49,12 @@ public class ParserDetector {
                 return JmeterSummarizerParser.class.getSimpleName();
             } else if (isLoadRunnerFileType(line)) {
                 return LoadRunnerParser.class.getSimpleName();
+            } else if (isLocustFileType(line)) {
+                return LocustParser.class.getSimpleName();
             } else {
                 try {
                     return detectXMLFileType(reportPath);
-                } catch (IllegalArgumentException ex) {
+                } catch (IllegalArgumentException | IllegalStateException ex) {
                     throw new IllegalArgumentException("Can not detect file type: " + reportPath, ex);
                 }
             }
@@ -164,4 +167,18 @@ public class ParserDetector {
         }
         throw new IllegalStateException("XML parsing error: no start element");
     }
+
+    /**
+     * Detect Locust report type using verification of csv header. Header names and order is asserted.
+     * @param line - single report file line
+     * @return true if Locust expected header found
+     */
+    private static boolean isLocustFileType(String line) {
+        String[] fileLineHeader = line.replaceAll("\"", "").split(",");
+        String[] expectedHeaderFields = new String[]{"Method", "Name", "# requests", "# failures",
+                "Median response time", "Average response time", "Min response time", "Max response time",
+                "Average Content Size", "Requests/s"};
+        return (Arrays.equals(fileLineHeader, expectedHeaderFields));
+    }
+
 }

--- a/src/test/java/hudson/plugins/performance/parsers/LocustParserTest.java
+++ b/src/test/java/hudson/plugins/performance/parsers/LocustParserTest.java
@@ -2,77 +2,69 @@ package hudson.plugins.performance.parsers;
 
 import hudson.plugins.performance.reports.PerformanceReport;
 import hudson.plugins.performance.reports.PerformanceReportTest;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
 
-public class LocustParserTest
-{
+import static org.junit.Assert.*;
+
+public class LocustParserTest {
     final static String FILE_NAME = "test_results_requests.csv";
     File requestReportFile;
     LocustParser locustParser;
     PerformanceReport report;
 
     @Before
-    public void setUp() throws Exception
-    {
+    public void setUp() throws Exception {
         requestReportFile = new File(getClass().getResource(String.format("/%s", FILE_NAME)).toURI());
         locustParser = new LocustParser(null, PerformanceReportTest.DEFAULT_PERCENTILES, PerformanceReport.INCLUDE_ALL);
         report = locustParser.parse(requestReportFile);
     }
 
     @Test
-    public void shouldCreateParser() throws Exception
-    {
-        Assert.assertNotNull(locustParser);
+    public void shouldCreateParser() throws Exception {
+        assertNotNull(locustParser);
     }
 
     @Test
-    public void parserShouldReturnGlobPattern() throws Exception
-    {
-        Assert.assertEquals("**/*.csv", locustParser.getDefaultGlobPattern());
+    public void parserShouldReturnGlobPattern() throws Exception {
+        assertEquals("**/*.csv", locustParser.getDefaultGlobPattern());
     }
 
     @Test
-    public void reportShouldContainSummarizedValues() throws Exception
-    {
-        Assert.assertEquals(4, report.getSummarizerSize());
-        Assert.assertEquals(1993, report.getSummarizerMax());
-        Assert.assertEquals(196, report.getSummarizerMin());
-        Assert.assertEquals(223, report.getSummarizerAvg());
+    public void reportShouldContainSummarizedValues() throws Exception {
+        assertEquals(4, report.getSummarizerSize());
+        assertEquals(1993, report.getSummarizerMax());
+        assertEquals(196, report.getSummarizerMin());
+        assertEquals(223, report.getSummarizerAvg());
     }
 
     @Test
-    public void reportShouldContainAllReports() throws Exception
-    {
+    public void reportShouldContainAllReports() throws Exception {
         String[] reportUris = new String[]{"big", "huge", "medium", "small"};
-        Assert.assertArrayEquals(reportUris, report.getUriReportMap().keySet().toArray(new String[0]));
+        assertArrayEquals(reportUris, report.getUriReportMap().keySet().toArray(new String[0]));
 
         for (String uri : reportUris) {
-            Assert.assertEquals(true, report.getUriReportMap().get(uri).hasSamples());
+            assertEquals(true, report.getUriReportMap().get(uri).hasSamples());
         }
     }
 
     @Test
-    public void reportHasValuesInUriReport()
-    {
-        Assert.assertEquals(false, report.getUriReportMap().get("big").isExcludeResponseTime());
-        Assert.assertEquals(370, report.getUriReportMap().get("big").getAverage());
-        Assert.assertEquals(1, report.getUriReportMap().get("big").samplesCount());
-        Assert.assertEquals(638.0, report.getUriReportMap().get("big").getAverageSizeInKb(), 0.001);
+    public void reportHasValuesInUriReport() {
+        assertEquals(false, report.getUriReportMap().get("big").isExcludeResponseTime());
+        assertEquals(370, report.getUriReportMap().get("big").getAverage());
+        assertEquals(1, report.getUriReportMap().get("big").samplesCount());
+        assertEquals(638.0, report.getUriReportMap().get("big").getAverageSizeInKb(), 0.001);
     }
 
     @Test
-    public void reportShouldContainTrafficSize()
-    {
-        Assert.assertEquals(71464.0, report.getTotalTrafficInKb(), 0.001);
+    public void reportShouldContainTrafficSize() {
+        assertEquals(71464.0, report.getTotalTrafficInKb(), 0.001);
     }
 
     @Test
-    public void reportShouldReturnProperFileName() throws Exception
-    {
-        Assert.assertEquals(FILE_NAME, report.getReportFileName());
+    public void reportShouldReturnProperFileName() throws Exception {
+        assertEquals(FILE_NAME, report.getReportFileName());
     }
 }

--- a/src/test/java/hudson/plugins/performance/parsers/LocustParserTest.java
+++ b/src/test/java/hudson/plugins/performance/parsers/LocustParserTest.java
@@ -1,0 +1,78 @@
+package hudson.plugins.performance.parsers;
+
+import hudson.plugins.performance.reports.PerformanceReport;
+import hudson.plugins.performance.reports.PerformanceReportTest;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+public class LocustParserTest
+{
+    final static String FILE_NAME = "test_results_requests.csv";
+    File requestReportFile;
+    LocustParser locustParser;
+    PerformanceReport report;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        requestReportFile = new File(getClass().getResource(String.format("/%s", FILE_NAME)).toURI());
+        locustParser = new LocustParser(null, PerformanceReportTest.DEFAULT_PERCENTILES, PerformanceReport.INCLUDE_ALL);
+        report = locustParser.parse(requestReportFile);
+    }
+
+    @Test
+    public void shouldCreateParser() throws Exception
+    {
+        Assert.assertNotNull(locustParser);
+    }
+
+    @Test
+    public void parserShouldReturnGlobPattern() throws Exception
+    {
+        Assert.assertEquals("**/*.csv", locustParser.getDefaultGlobPattern());
+    }
+
+    @Test
+    public void reportShouldContainSummarizedValues() throws Exception
+    {
+        Assert.assertEquals(4, report.getSummarizerSize());
+        Assert.assertEquals(1993, report.getSummarizerMax());
+        Assert.assertEquals(196, report.getSummarizerMin());
+        Assert.assertEquals(223, report.getSummarizerAvg());
+    }
+
+    @Test
+    public void reportShouldContainAllReports() throws Exception
+    {
+        String[] reportUris = new String[]{"big", "huge", "medium", "small"};
+        Assert.assertArrayEquals(reportUris, report.getUriReportMap().keySet().toArray(new String[0]));
+
+        for (String uri : reportUris) {
+            Assert.assertEquals(true, report.getUriReportMap().get(uri).hasSamples());
+        }
+    }
+
+    @Test
+    public void reportHasValuesInUriReport()
+    {
+        Assert.assertEquals(false, report.getUriReportMap().get("big").isExcludeResponseTime());
+        Assert.assertEquals(370, report.getUriReportMap().get("big").getAverage());
+        Assert.assertEquals(1, report.getUriReportMap().get("big").samplesCount());
+        Assert.assertEquals(638.0, report.getUriReportMap().get("big").getAverageSizeInKb(), 0.001);
+    }
+
+    @Test
+    public void reportShouldContainTrafficSize()
+    {
+        Assert.assertEquals(71464.0, report.getTotalTrafficInKb(), 0.001);
+    }
+
+    @Test
+    public void reportShouldReturnProperFileName() throws Exception
+    {
+        Assert.assertEquals(FILE_NAME, report.getReportFileName());
+    }
+}

--- a/src/test/java/hudson/plugins/performance/parsers/ParserDetectorTest.java
+++ b/src/test/java/hudson/plugins/performance/parsers/ParserDetectorTest.java
@@ -64,6 +64,11 @@ public class ParserDetectorTest {
         assertEquals(JMeterParser.class.getSimpleName(), ParserDetector.detectXMLFileType(getHugeJMeterInputStream()));
     }
 
+    @Test
+    public void testLocustReport() throws Exception {
+        String filePath = getClass().getResource("/test_results_requests.csv").toURI().getPath();
+        assertEquals(LocustParser.class.getSimpleName(), ParserDetector.detect(filePath));
+    }
 
     public static InputStream getHugeJMeterInputStream() {
         return new SequenceInputStream(getPrefixInputStream(), getInfiniteSampleInputStream());

--- a/src/test/resources/test_results_requests.csv
+++ b/src/test/resources/test_results_requests.csv
@@ -1,0 +1,6 @@
+"Method","Name","# requests","# failures","Median response time","Average response time","Min response time","Max response time","Average Content Size","Requests/s"
+"POST","big",638,10,400,370,198,906,1,1.07
+"POST","huge",72,0,800,865,411,1993,1,0.12
+"POST","medium",6535,0,200,221,197,469,1,10.91
+"POST","small",64219,0,200,221,196,1009,1,107.22
+"None","Total",71464,10000,200,223,196,1993,1,119.31


### PR DESCRIPTION
This code is implementation of [locustio](https://locust.io/) reports parser. 

It expects the reports generated in Locust *csv format as described in [documentation](https://docs.locust.io/en/stable/retrieving-stats.html?highlight=csv).