### PR TITLE
Response times scatter plot

### DIFF
--- a/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
+++ b/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
@@ -33,6 +33,7 @@ import org.jfree.chart.plot.PlotOrientation;
 import org.jfree.chart.plot.XYPlot;
 import org.jfree.chart.renderer.category.BarRenderer;
 import org.jfree.chart.renderer.category.LineAndShapeRenderer;
+import org.jfree.chart.renderer.xy.XYDotRenderer;
 import org.jfree.chart.renderer.xy.XYItemRenderer;
 import org.jfree.chart.title.LegendTitle;
 import org.jfree.data.category.CategoryDataset;

--- a/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
+++ b/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
@@ -298,7 +298,10 @@ public class PerformanceProjectAction implements Action {
         final DateAxis axis = (DateAxis) plot.getDomainAxis();
         axis.setDateFormatOverride(new SimpleDateFormat("HH:mm:ss"));
 
-        final XYItemRenderer renderer = plot.getRenderer();
+        final XYDotRenderer renderer = new XYDotRenderer(); // scatter plot
+        plot.setRenderer(renderer);
+        renderer.setDotWidth(2);
+        renderer.setDotHeight(2);
         renderer.setSeriesPaint(0, ColorPalette.RED);
 
         return chart;


### PR DESCRIPTION
The plugin currently publishes response time charts for the build based on the stored sample data, both on the `/performance/trendReport` and  `/performance/uriReport` page.
These charts are line charts, with each individual sample being plotted and connected with straight lines (first example below).
This is not ideal as it hides significant details (clustering, queuing, gaps, outlier etc.) and would be much better presented as scatter plot, i.e. individual dots without lines in between (second example below).
This PR implements this change, which is purely affecting presentation of the same data.
![before](https://user-images.githubusercontent.com/19366960/75296034-07a55780-5891-11ea-8c0d-6237b126df93.png)
![after](https://user-images.githubusercontent.com/19366960/75296041-0a07b180-5891-11ea-9b12-c16aba4a0c49.png)

