### PR TITLE
Add percentile and throughput chart to URI report page

### DIFF
--- a/src/main/java/hudson/plugins/performance/TrendReportGraphs.java
+++ b/src/main/java/hudson/plugins/performance/TrendReportGraphs.java
@@ -29,8 +29,7 @@ public class TrendReportGraphs implements ModelObject {
         this.project = project;
     }
 
-    public void doRespondingTimeGraph(StaplerRequest request,
-                                      StaplerResponse response) throws IOException {
+    private UriReport getUriReportForRequest(StaplerRequest request) {
 
         PerformanceReportPosition performanceReportPosition = new PerformanceReportPosition();
         request.bindParameters(performanceReportPosition);
@@ -41,9 +40,33 @@ public class TrendReportGraphs implements ModelObject {
         if (performanceBuildAction != null && performanceReport != null) {
             String uri = performanceReportPosition.getSummarizerTrendUri();
             if (uri != null) {
-                UriReport uriReport = performanceReport.getUriReportMap().get(uri);
-                uriReport.doSummarizerTrendGraph(request, response);
+                return performanceReport.getUriReportMap().get(uri);
             }
+        }
+        return null;
+    }
+
+    public void doRespondingTimeGraph(StaplerRequest request,
+                                      StaplerResponse response) throws IOException {
+        UriReport uriReport = getUriReportForRequest(request);
+        if (uriReport != null) {
+            uriReport.doSummarizerTrendGraph(request, response);
+        }
+    }
+
+    public void doPercentileGraph(StaplerRequest request,
+                                  StaplerResponse response) throws IOException {
+        UriReport uriReport = getUriReportForRequest(request);
+        if (uriReport != null) {
+            uriReport.doPercentileGraph(request, response);
+        }
+    }
+
+    public void doThroughputGraph(StaplerRequest request,
+                                  StaplerResponse response) throws IOException {
+        UriReport uriReport = getUriReportForRequest(request);
+        if (uriReport != null) {
+            uriReport.doThroughputGraph(request, response);
         }
     }
 

--- a/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
+++ b/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
@@ -33,9 +33,11 @@ import org.jfree.chart.plot.PlotOrientation;
 import org.jfree.chart.plot.XYPlot;
 import org.jfree.chart.renderer.category.BarRenderer;
 import org.jfree.chart.renderer.category.LineAndShapeRenderer;
+import org.jfree.chart.renderer.xy.XYBarRenderer;
 import org.jfree.chart.renderer.xy.XYItemRenderer;
 import org.jfree.chart.title.LegendTitle;
 import org.jfree.data.category.CategoryDataset;
+import org.jfree.data.xy.IntervalXYDataset;
 import org.jfree.data.xy.XYDataset;
 import org.jfree.ui.RectangleEdge;
 import org.jfree.ui.RectangleInsets;
@@ -300,6 +302,56 @@ public class PerformanceProjectAction implements Action {
 
         final XYItemRenderer renderer = plot.getRenderer();
         renderer.setSeriesPaint(0, ColorPalette.RED);
+
+        return chart;
+    }
+
+    public static JFreeChart createUriPercentileChart(XYDataset dataset, String uri) {
+        final JFreeChart chart = ChartFactory.createXYLineChart(uri, Messages.TrendReportDetail_Percent(),
+                Messages.TrendReportDetail_ResponseTime(), dataset,
+                PlotOrientation.VERTICAL, true, true, false);
+        chart.setBackgroundPaint(Color.WHITE);
+
+        final XYPlot plot = chart.getXYPlot();
+        plot.setBackgroundPaint(Color.WHITE);
+        plot.setDomainGridlinePaint(Color.BLACK);
+        plot.setRangeGridlinePaint(Color.BLACK);
+
+        // Exclude zeroes to make sure y-axis aligns with response time auto range:
+        final NumberAxis yaxis = (NumberAxis) plot.getRangeAxis();
+        yaxis.setAutoRange(true);
+        yaxis.setAutoRangeIncludesZero(false);
+
+        final NumberAxis xaxis = (NumberAxis) plot.getDomainAxis();
+        xaxis.setRange(0, 100); // avoid auto margin
+
+        final XYItemRenderer renderer = plot.getRenderer();
+        renderer.setSeriesPaint(0, ColorPalette.RED);
+
+        return chart;
+    }
+
+    public static JFreeChart createUriThroughputChart(IntervalXYDataset dataset, String uri) {
+        final JFreeChart chart = ChartFactory.createXYBarChart(uri,  Messages.TrendReportDetail_Time(), true,
+                Messages.TrendReportDetail_RequestsPerMinute(), dataset,
+                PlotOrientation.VERTICAL,true, true, false);
+        chart.setBackgroundPaint(Color.WHITE);
+
+        final XYPlot plot = chart.getXYPlot();
+        plot.setBackgroundPaint(Color.WHITE);
+        plot.setDomainGridlinePaint(Color.BLACK);
+        plot.setRangeGridlinePaint(Color.BLACK);
+
+        final DateAxis axis = (DateAxis) plot.getDomainAxis();
+        axis.setDateFormatOverride(new SimpleDateFormat("HH:mm:ss"));
+
+        final XYBarRenderer renderer = (XYBarRenderer) plot.getRenderer();
+        // As of Jenkins v2.198 jfreechart v1.0.19 paints bars with a gradient by default
+        // which can't be turned off in v1.0.9 the plugin is compiled against
+        // so instead use a red outline and fill with white:
+        renderer.setSeriesPaint(0, Color.WHITE);
+        renderer.setDrawBarOutline(true);
+        renderer.setSeriesOutlinePaint(0, ColorPalette.RED);
 
         return chart;
     }

--- a/src/main/resources/hudson/plugins/performance/Messages.properties
+++ b/src/main/resources/hudson/plugins/performance/Messages.properties
@@ -21,6 +21,12 @@ CsvParser.validation.patternEmpty=Pattern is required
 
 GraphConfigurationDetail.DisplayName=Configure
 TrendReportDetail.DisplayName=Trend report
+TrendReportDetail.ResponseTime=Response Time (ms)
+TrendReportDetail.Time=Time
+TrendReportDetail.Percent=Percent
+TrendReportDetail.RequestsPerMinute=Requests Per Minute
+TrendReportDetail.RequestThroughput=Request Throughput
+TrendReportDetail_ResponseTimePercentiles=Response Time Percentiles
 TestSuiteReportDetail.DisplayName=Test Suite report
 PerformanceTest.Name=Run Performance Test
 PerformanceTest.Config=Performance Test

--- a/src/main/resources/hudson/plugins/performance/reports/UriReport/index.jelly
+++ b/src/main/resources/hudson/plugins/performance/reports/UriReport/index.jelly
@@ -8,6 +8,12 @@
             <a href="./summarizerTrendGraph?width=1500&amp;height=650&amp;performanceReportPosition=${performanceReport}"  title="${%Click for larger image}">
                 <img class="trend" src="./summarizerTrendGraph?width=600&amp;height=325&amp;performanceReportPosition=${performanceReport}" width="600" height="325" />
             </a>
+            <a href="./percentileGraph?width=1500&amp;height=650&amp;performanceReportPosition=${it.filename}&amp;summarizerTrendUri=${URI}" title="${%Click for larger image}">
+                <img class="trend" src="./percentileGraph?width=600&amp;height=325&amp;performanceReportPosition=${it.filename}&amp;summarizerTrendUri=${URI}" width="600" height="325" />
+            </a>
+            <a href="./throughputGraph?width=1500&amp;height=650&amp;performanceReportPosition=${it.filename}&amp;summarizerTrendUri=${URI}" title="${%Click for larger image}">
+                <img class="trend" src="./throughputGraph?width=600&amp;height=325&amp;performanceReportPosition=${it.filename}&amp;summarizerTrendUri=${URI}" width="600" height="325" />
+            </a>
         </j:if>
         <br></br>
       <strong class="uri">URI: ${it.uri}</strong>


### PR DESCRIPTION
For each test run, on the `/performance/uriReport` page the plugin currently plots response times over time.
However, it would be nice and easy to present more charts as the build contains all the sample data.
This PR adds two more charts (example below): 
- Response time percentiles
- Request throughput over time (in requests per minute)

Happy to add unit tests if this PR idea is generally accepted.

![example](https://user-images.githubusercontent.com/19366960/75405838-ac986100-5973-11ea-9499-44eb2aab232f.png)
