### PR TITLE
Add error chart to URI report page

### DIFF
--- a/src/main/java/hudson/plugins/performance/TrendReportGraphs.java
+++ b/src/main/java/hudson/plugins/performance/TrendReportGraphs.java
@@ -70,6 +70,14 @@ public class TrendReportGraphs implements ModelObject {
         }
     }
 
+    public void doErrorGraph(StaplerRequest request,
+                                  StaplerResponse response) throws IOException {
+        UriReport uriReport = getUriReportForRequest(request);
+        if (uriReport != null) {
+            uriReport.doErrorGraph(request, response);
+        }
+    }
+
     public ArrayList<String> getUris() {
         ArrayList<String> uriList = new ArrayList<>();
         PerformanceReport report = getPerformanceReport();

--- a/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
+++ b/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
@@ -278,8 +278,8 @@ public class PerformanceProjectAction implements Action {
     public static JFreeChart createSummarizerTrend(
             ArrayList<XYDataset> dataset, String uri) {
 
-        final JFreeChart chart = ChartFactory.createTimeSeriesChart(uri, "Time",
-                "Response Time", dataset.get(0), true, true, false);
+        final JFreeChart chart = ChartFactory.createTimeSeriesChart(uri, Messages.TrendReportDetail_Time(),
+                Messages.TrendReportDetail_ResponseTime(), dataset.get(0), true, true, false);
         chart.setBackgroundPaint(Color.WHITE);
 
         final XYPlot plot = chart.getXYPlot();

--- a/src/main/java/hudson/plugins/performance/reports/UriReport.java
+++ b/src/main/java/hudson/plugins/performance/reports/UriReport.java
@@ -446,7 +446,7 @@ public class UriReport extends AbstractReport implements Serializable, ModelObje
     }
 
     public void doSummarizerTrendGraph(StaplerRequest request, StaplerResponse response) throws IOException {
-        TimeSeries responseTimes = new TimeSeries("Response Time", FixedMillisecond.class);
+        TimeSeries responseTimes = new TimeSeries(Messages.ProjectAction_RespondingTime(), FixedMillisecond.class);
         synchronized (samples) {
             for (Sample sample : samples) {
                 if (isIncludeResponseTime(sample)) {
@@ -461,6 +461,23 @@ public class UriReport extends AbstractReport implements Serializable, ModelObje
         ArrayList<XYDataset> dataset = new ArrayList<>();
         dataset.add(resp);
 
+        ChartUtil.generateGraph(request, response,
+                PerformanceProjectAction.createSummarizerTrend(dataset, uri), 400, 200);
+    }
+
+    public void doErrorGraph(StaplerRequest request, StaplerResponse response) throws IOException {
+        TimeSeries errors = new TimeSeries(Messages.ProjectAction_Errors(), FixedMillisecond.class);
+        synchronized (samples) {
+            for (Sample sample : samples) {
+                if (sample.isFailed() && !sample.isSummarizer()) {
+                    errors.addOrUpdate(new FixedMillisecond(sample.date), sample.duration);
+                }
+            }
+        }
+        ArrayList<XYDataset> dataset = new ArrayList<>();
+        dataset.add(new TimeSeriesCollection(errors));
+
+        // Re-use the same scatter plotter for error response times:
         ChartUtil.generateGraph(request, response,
                 PerformanceProjectAction.createSummarizerTrend(dataset, uri), 400, 200);
     }

--- a/src/main/resources/hudson/plugins/performance/reports/UriReport/index.jelly
+++ b/src/main/resources/hudson/plugins/performance/reports/UriReport/index.jelly
@@ -14,6 +14,9 @@
             <a href="./throughputGraph?width=1500&amp;height=650&amp;performanceReportPosition=${it.filename}&amp;summarizerTrendUri=${URI}" title="${%Click for larger image}">
                 <img class="trend" src="./throughputGraph?width=600&amp;height=325&amp;performanceReportPosition=${it.filename}&amp;summarizerTrendUri=${URI}" width="600" height="325" />
             </a>
+            <a href="./errorGraph?width=1500&amp;height=650&amp;performanceReportPosition=${performanceReport}" title="${%Click for larger image}">
+                <img class="trend" src="./errorGraph?width=600&amp;height=325&amp;performanceReportPosition=${performanceReport}" width="600" height="325" />
+            </a>
         </j:if>
         <br></br>
       <strong class="uri">URI: ${it.uri}</strong>


### PR DESCRIPTION
Similar to #193, the URI report page may show how error responses are distributed over time in a scatter plot.

Example:
![after](https://user-images.githubusercontent.com/19366960/80549423-54341d00-8a11-11ea-90df-e1749821e60e.png)
