### PR TITLE
Feature to enable/disable trend graphs in performance report [JENKINS-64638]

### DIFF
--- a/src/main/java/hudson/plugins/performance/PerformancePublisher.java
+++ b/src/main/java/hudson/plugins/performance/PerformancePublisher.java
@@ -127,6 +127,11 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
     private boolean excludeResponseTime;
 
     /**
+     * Show Trends mode.
+     */
+    private boolean showTrendGraphs;
+
+    /**
      * @deprecated as of 1.3. for compatibility
      */
     private transient String filename; // NOSONAR On purpose keep of transient, we don't want to save it
@@ -198,9 +203,10 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
                                 boolean failBuildIfNoResultFile,
                                 boolean compareBuildPrevious,
                                 boolean modeThroughput,
+                                boolean showTrendGraphs,
                                 /**
-                                 * Deprecated. Now use for support previous pipeline jobs.
-                                 */
+                                     * Deprecated. Now use for support previous pipeline jobs.
+                                     */
                                 List<PerformanceReportParser> parsers) {
         this.parsers = parsers;
         this.sourceDataFiles = sourceDataFiles;
@@ -209,6 +215,7 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
         this.errorFailedThreshold = errorFailedThreshold;
         this.errorUnstableThreshold = errorUnstableThreshold;
         this.errorUnstableResponseTimeThreshold = errorUnstableResponseTimeThreshold;
+        this.showTrendGraphs = showTrendGraphs;
 
         this.relativeFailedThresholdPositive = relativeFailedThresholdPositive;
         this.relativeFailedThresholdNegative = relativeFailedThresholdNegative;
@@ -475,6 +482,7 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
     private void prepareParsers(Collection<PerformanceReportParser> performanceReportParsers) {
         for (PerformanceReportParser parser : performanceReportParsers) {
             parser.setExcludeResponseTime(excludeResponseTime);
+            parser.setShowTrendGraphs(showTrendGraphs);
             parser.setBaselineBuild(baselineBuild);
         }
     }
@@ -1320,6 +1328,19 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
     @DataBoundSetter
     public void setModeEvaluation(boolean modeEvaluation) {
         this.modeEvaluation = modeEvaluation;
+    }
+
+    @DataBoundSetter
+    public void setShowTrendGraphs(boolean showTrendGraphs) {
+        this.showTrendGraphs = showTrendGraphs;
+    }
+
+    public boolean isShowTrendGraphs() {
+        return showTrendGraphs;
+    }
+
+    public boolean getShowTrendGraphs() {
+        return showTrendGraphs;
     }
 
     public String getSourceDataFiles() {

--- a/src/main/java/hudson/plugins/performance/PerformanceReportMap.java
+++ b/src/main/java/hudson/plugins/performance/PerformanceReportMap.java
@@ -138,6 +138,11 @@ public class PerformanceReportMap implements ModelObject {
         return publisher == null || publisher.isModeThroughput();
     }
 
+    public boolean ifShowTrendGraphsUsed() {
+        PerformancePublisher publisher = getPublisher();
+        return publisher.isShowTrendGraphs();
+    }
+
     public boolean ifModePerformancePerTestCaseUsed() {
         PerformancePublisher publisher = getPublisher();
         return publisher == null || publisher.isModePerformancePerTestCase();

--- a/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
+++ b/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
@@ -223,7 +223,7 @@ public class PerformanceTestBuild extends Builder implements SimpleBuildStep {
     }
 
     protected void generatePerformanceTrend(String path, Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
-        new PerformancePublisher(path + "/aggregate-results.xml", -1, -1, "", 0, 0, 0, 0, 0, false, "", false, false, false, false, null).
+        new PerformancePublisher(path + "/aggregate-results.xml", -1, -1, "", 0, 0, 0, 0, 0, false, "", false, false, false, false,false, null).
                 perform(run, workspace, launcher, listener);
     }
 

--- a/src/main/java/hudson/plugins/performance/parsers/IagoParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/IagoParser.java
@@ -65,6 +65,7 @@ public class IagoParser extends AbstractParser {
     PerformanceReport parse(File reportFile) throws Exception {
         final PerformanceReport report = createPerformanceReport();
         report.setExcludeResponseTime(excludeResponseTime);
+        report.setShowTrendGraphs(showTrendGraphs);
         report.setReportFileName(reportFile.getName());
 
         try (FileReader fr = new FileReader(reportFile);

--- a/src/main/java/hudson/plugins/performance/parsers/JMeterCsvParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/JMeterCsvParser.java
@@ -55,6 +55,7 @@ public class JMeterCsvParser extends AbstractParser {
 
         final PerformanceReport report = createPerformanceReport();
         report.setExcludeResponseTime(excludeResponseTime);
+        report.setShowTrendGraphs(showTrendGraphs);
         report.setReportFileName(reportFile.getName());
 
         String[] header = null;

--- a/src/main/java/hudson/plugins/performance/parsers/JMeterParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/JMeterParser.java
@@ -95,6 +95,7 @@ public class JMeterParser extends AbstractParser {
 
         final PerformanceReport report = createPerformanceReport();
         report.setExcludeResponseTime(excludeResponseTime);
+        report.setShowTrendGraphs(showTrendGraphs);
         report.setReportFileName(reportFile.getName());
 
         factory.newSAXParser().parse(reportFile, new DefaultHandler() {

--- a/src/main/java/hudson/plugins/performance/parsers/JUnitParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/JUnitParser.java
@@ -57,6 +57,7 @@ public class JUnitParser extends AbstractParser {
         final SAXParser parser = factory.newSAXParser();
         final PerformanceReport report = createPerformanceReport();
         report.setExcludeResponseTime(excludeResponseTime);
+        report.setShowTrendGraphs(showTrendGraphs);
         report.setReportFileName(reportFile.getName());
         parser.parse(reportFile, new DefaultHandler() {
             private HttpSample currentSample;

--- a/src/main/java/hudson/plugins/performance/parsers/JmeterSummarizerParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/JmeterSummarizerParser.java
@@ -47,6 +47,7 @@ public class JmeterSummarizerParser extends AbstractParser {
 
         final PerformanceReport report = createPerformanceReport();
         report.setExcludeResponseTime(excludeResponseTime);
+        report.setShowTrendGraphs(showTrendGraphs);
         report.setReportFileName(reportFile.getName());
 
         try (Scanner fileScanner = new Scanner(reportFile)){

--- a/src/main/java/hudson/plugins/performance/parsers/LoadRunnerParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/LoadRunnerParser.java
@@ -78,6 +78,7 @@ public class LoadRunnerParser extends AbstractParser {
     PerformanceReport parse(File reportFile) throws Exception {
         final PerformanceReport report = createPerformanceReport();
         report.setExcludeResponseTime(excludeResponseTime);
+        report.setShowTrendGraphs(showTrendGraphs);
         report.setReportFileName(reportFile.getName());
 
         try (Connection con = DriverManager.getConnection(jdbcUrlForFile(reportFile));

--- a/src/main/java/hudson/plugins/performance/parsers/LocustParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/LocustParser.java
@@ -39,6 +39,7 @@ public class LocustParser extends AbstractParser {
         PerformanceReport report = createPerformanceReport();
         report.setReportFileName(reportFile.getName());
         report.setExcludeResponseTime(excludeResponseTime);
+        report.setShowTrendGraphs(showTrendGraphs);
         List<CSVRecord> reportData = getCsvData(reportFile);
         final Date now = new Date();
 

--- a/src/main/java/hudson/plugins/performance/parsers/PerformanceReportParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/PerformanceReportParser.java
@@ -35,6 +35,7 @@ public abstract class PerformanceReportParser implements
      * Exclude response time of errored samples
      */
     protected boolean excludeResponseTime;
+    protected boolean showTrendGraphs;
     protected int baselineBuild;
 
     protected PerformanceReportParser(String glob) {
@@ -73,6 +74,14 @@ public abstract class PerformanceReportParser implements
 
     public void setExcludeResponseTime(boolean excludeResponseTime) {
         this.excludeResponseTime = excludeResponseTime;
+    }
+
+    public boolean isShowTrendGraphs() {
+        return showTrendGraphs;
+    }
+
+    public void setShowTrendGraphs(boolean showTrendGraphs) {
+        this.showTrendGraphs = showTrendGraphs;
     }
 
     public void setBaselineBuild(int baselineBuild) {

--- a/src/main/java/hudson/plugins/performance/parsers/TaurusParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/TaurusParser.java
@@ -51,6 +51,7 @@ public class TaurusParser extends AbstractParser {
     private PerformanceReport readFromXML(File reportFile) throws Exception {
         final PerformanceReport report = createPerformanceReport();
         report.setExcludeResponseTime(excludeResponseTime);
+        report.setShowTrendGraphs(showTrendGraphs);
         report.setReportFileName(reportFile.getName());
 
         DocumentBuilderFactory dbFactory

--- a/src/main/java/hudson/plugins/performance/parsers/WrkSummarizerParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/WrkSummarizerParser.java
@@ -81,6 +81,7 @@ public class WrkSummarizerParser extends AbstractParser {
     PerformanceReport parse(File reportFile) throws Exception {
         final PerformanceReport r = createPerformanceReport();
         r.setExcludeResponseTime(excludeResponseTime);
+        r.setShowTrendGraphs(showTrendGraphs);
         r.setReportFileName(reportFile.getName());
 
         Scanner s = null;

--- a/src/main/java/hudson/plugins/performance/reports/AbstractReport.java
+++ b/src/main/java/hudson/plugins/performance/reports/AbstractReport.java
@@ -38,6 +38,8 @@ public abstract class AbstractReport {
      */
     protected boolean excludeResponseTime;
 
+    protected boolean showTrendGraphs;
+
     public abstract int countErrors();
 
     public abstract double errorPercent();
@@ -141,6 +143,14 @@ public abstract class AbstractReport {
 
     public void setExcludeResponseTime(boolean excludeResponseTime) {
         this.excludeResponseTime = excludeResponseTime;
+    }
+
+    public boolean isShowTrendGraphs() {
+        return showTrendGraphs;
+    }
+
+    public void setShowTrendGraphs(boolean showTrendGraphs) {
+        this.showTrendGraphs = showTrendGraphs;
     }
 
     protected boolean isIncludeResponseTime(HttpSample sample) {

--- a/src/main/java/hudson/plugins/performance/reports/PerformanceReport.java
+++ b/src/main/java/hudson/plugins/performance/reports/PerformanceReport.java
@@ -163,6 +163,7 @@ public class PerformanceReport extends AbstractReport implements Serializable,
             if (uriReport == null) {
                 uriReport = new UriReport(this, staplerUri, uri);
                 uriReport.setExcludeResponseTime(excludeResponseTime);
+                uriReport.setShowTrendGraphs(showTrendGraphs);
                 uriReportMap.put(staplerUri, uriReport);
             }
             uriReport.addHttpSample(pHttpSample);

--- a/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.jelly
@@ -9,6 +9,11 @@
       <f:textbox />
    </f:entry>
 
+  <f:entry title="Show Trend Graphs" field="showTrendGraphs" >
+    <f:checkbox name="showTrendGraphs" field="showTrendGraphs" >
+    </f:checkbox>
+  </f:entry>
+
   <f:entry title="Select evaluation mode" field="modeEvaluation">
     <f:booleanRadio name="modeEvaluation"  false="Standard Mode" true="Expert Mode" />
   </f:entry> 

--- a/src/main/resources/hudson/plugins/performance/PerformanceReportMap/index.jelly
+++ b/src/main/resources/hudson/plugins/performance/PerformanceReportMap/index.jelly
@@ -7,32 +7,32 @@
       <j:forEach var="performanceReport" items="${it.getPerformanceListOrdered()}">
         <h2>${%Performance Breakdown by URI}: ${performanceReport.getReportFileName()}</h2>
 
-         <j:if test="${it.ifModeThroughputUsed()}">
-             <img class="trend" src="./throughputGraph?width=600&amp;height=225&amp;performanceReportPosition=${performanceReport.getReportFileName()}" width="600" height="225" />
-         </j:if>
+          <j:if test="${it.ifShowTrendGraphsUsed()}">
+            <j:if test="${it.ifModeThroughputUsed()}">
+              <img class="trend" src="./throughputGraph?width=600&amp;height=225&amp;performanceReportPosition=${performanceReport.getReportFileName()}" width="600" height="225" />
+            </j:if>
 
-         <j:choose>
-          <j:when test="${performanceReport.ifSummarizerParserUsed(performanceReport.getReportFileName())}">
-            <img class="trend" src="./summarizerGraph?width=600&amp;height=325&amp;performanceReportPosition=${performanceReport.getReportFileName()}" width="600" height="325" />
-          </j:when>
-          <j:otherwise>
             <j:choose>
-                <j:when test="${it.ifModePerformancePerTestCaseUsed()}">
-                    <a href="./respondingTimeGraphPerTestCaseMode?width=900&amp;height=550&amp;performanceReportPosition=${performanceReport.getReportFileName()}" title="${%Click for larger image}">
-                        <img class="trend" src="./respondingTimeGraphPerTestCaseMode?width=600&amp;height=225&amp;legendLimit=5&amp;performanceReportPosition=${performanceReport.getReportFileName()}" width="600" height="225" />
+              <j:when test="${performanceReport.ifSummarizerParserUsed(performanceReport.getReportFileName())}">
+                <img class="trend" src="./summarizerGraph?width=600&amp;height=325&amp;performanceReportPosition=${performanceReport.getReportFileName()}" width="600" height="325" />
+              </j:when>
+              <j:otherwise>
+                <j:choose>
+                  <j:when test="${it.ifModePerformancePerTestCaseUsed()}">
+                    <a href="./respondingTimeGraphPerTestCaseMode?width=900&amp;height=550&amp;performanceReportPosition=${performanceReport.getReportFileName()}" title="${%Click for larger image}">                                <img class="trend" src="./respondingTimeGraphPerTestCaseMode?width=600&amp;height=225&amp;legendLimit=5&amp;performanceReportPosition=${performanceReport.getReportFileName()}" width="600" height="225" />
                     </a>
-                </j:when>
-                <j:otherwise>
+                  </j:when>
+                  <j:otherwise>
                     <a href="./respondingTimeGraph?width=900&amp;height=550&amp;performanceReportPosition=${performanceReport.getReportFileName()}" title="${%Click for larger image}">
-                        <img class="trend" src="./respondingTimeGraph?width=600&amp;height=225&amp;legendLimit=5&amp;performanceReportPosition=${performanceReport.getReportFileName()}" width="600" height="225" />
+                      <img class="trend" src="./respondingTimeGraph?width=600&amp;height=225&amp;legendLimit=5&amp;performanceReportPosition=${performanceReport.getReportFileName()}" width="600" height="225" />
                     </a>
-                </j:otherwise>
+                  </j:otherwise>
+                </j:choose>
+              </j:otherwise>
             </j:choose>
-          </j:otherwise>
-         </j:choose>
 
-        <img class="trend" src="./errorsGraph?width=600&amp;height=225&amp;performanceReportPosition=${performanceReport.getReportFileName()}" width="600" height="225" />
-
+            <img class="trend" src="./errorsGraph?width=600&amp;height=225&amp;performanceReportPosition=${performanceReport.getReportFileName()}" width="600" height="225" />
+          </j:if>
         <p><a href="./trendReport?performanceReportPosition=${performanceReport.getReportFileName()}">${% Response time trends for build: }"${it.build}" </a></p>
 
         <j:choose>
@@ -73,7 +73,7 @@
            </j:otherwise>
           </j:choose>
         </table>
-      </j:forEach> 
+      </j:forEach>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/src/test/java/hudson/plugins/performance/PerformancePublisherTest.java
+++ b/src/test/java/hudson/plugins/performance/PerformancePublisherTest.java
@@ -61,7 +61,7 @@ public class PerformancePublisherTest extends HudsonTestCase {
             }
         });
         p.getPublishersList().add(
-                new PerformancePublisher("", 0, 0, "", 0, 0, 0, 0, 0, false, "", false, false, false, false, null));
+                new PerformancePublisher("", 0, 0, "", 0, 0, 0, 0, 0, false, "", false, false, false, false,false, null));
 
         FreeStyleBuild b = assertBuildStatusSuccess(p.scheduleBuild2(0).get());
         PerformanceBuildAction a = b.getAction(PerformanceBuildAction.class);
@@ -93,7 +93,7 @@ public class PerformancePublisherTest extends HudsonTestCase {
         List<PerformanceReportParser> parsers = new ArrayList<PerformanceReportParser>();
         parsers.add(new JMeterParser("test.jtl", PerformanceReportTest.DEFAULT_PERCENTILES));
 
-        PerformancePublisher publisher = new PerformancePublisher("", 0, 0, "", 0, 0, 0, 0, 0, false, "", false, false, false, false, parsers);
+        PerformancePublisher publisher = new PerformancePublisher("", 0, 0, "", 0, 0, 0, 0, 0, false, "", false, false, false, false,false, parsers);
         publisher.setModeEvaluation(false);
         p.getPublishersList().add(publisher);
 
@@ -143,7 +143,7 @@ public class PerformancePublisherTest extends HudsonTestCase {
             }
         });
         p.getPublishersList().add(
-                new PerformancePublisher("", 0, 0, "", 0, 0, 0, 0, 0, false, "", false, false, false, false, null));
+                new PerformancePublisher("", 0, 0, "", 0, 0, 0, 0, 0, false, "", false, false, false, false,false, null));
 
         FreeStyleBuild b = assertBuildStatusSuccess(p.scheduleBuild2(0).get());
         PerformanceBuildAction a = b.getAction(PerformanceBuildAction.class);
@@ -174,7 +174,7 @@ public class PerformancePublisherTest extends HudsonTestCase {
             }
         });
         p.getPublishersList().add(
-                new PerformancePublisher("test.jtl", 0, 0, "test.jtl:100", 0, 0, 0, 0, 0, false, "", false, false, false, false, null));
+                new PerformancePublisher("test.jtl", 0, 0, "test.jtl:100", 0, 0, 0, 0, 0, false, "", false, false, false, false,false, null));
 
         FreeStyleBuild b = assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0).get());
         PerformanceBuildAction a = b.getAction(PerformanceBuildAction.class);
@@ -205,7 +205,7 @@ public class PerformancePublisherTest extends HudsonTestCase {
             }
         });
         p.getPublishersList().add(
-                new PerformancePublisher("", 0, 0, "test.jtl:5000", 0, 0, 0, 0, 0, false, "", false, false, false, false, null));
+                new PerformancePublisher("", 0, 0, "test.jtl:5000", 0, 0, 0, 0, 0, false, "", false, false, false, false,false, null));
 
         FreeStyleBuild b = assertBuildStatusSuccess(p.scheduleBuild2(0).get());
         PerformanceBuildAction a = b.getAction(PerformanceBuildAction.class);
@@ -233,7 +233,7 @@ public class PerformancePublisherTest extends HudsonTestCase {
         FreeStyleProject p = createFreeStyleProject();
 
         p.getPublishersList().add(
-                new PerformancePublisher("", 0, 0, null, 100.0d, 0, 50.0d, 0, 0, false, "ART", true, false, true, false, null));
+                new PerformancePublisher("", 0, 0, null, 100.0d, 0, 50.0d, 0, 0, false, "ART", true, false, true, false,false, null));
         // first build
         p.getBuildersList().add(new TestBuilder() {
             @Override
@@ -268,7 +268,7 @@ public class PerformancePublisherTest extends HudsonTestCase {
     @Test
     public void testEmptyReportParsersList() throws Exception {
         PerformancePublisher publisher = new PerformancePublisher("", 0, 0, "", 0.0, 0.0, 0.0, 0.0, 0, true, "MRT",
-                true, true, true, true, null);
+                true, true, true, true,false, null);
         RunExt run = new RunExt( createFreeStyleProject());
         run.onStartBuilding();
         try {
@@ -294,7 +294,7 @@ public class PerformancePublisherTest extends HudsonTestCase {
     public void testOptionMethods() throws Exception {
         final double DELTA = 0.001;
         PerformancePublisher publisher = new PerformancePublisher("reportFile.xml", 15, 16, "reportFile.xml:100", 9.0, 8.0, 7.0, 6.0, 3, true, "MRT",
-                true, true, true, true, null);
+                true, true, true, true,false, null);
         assertEquals("reportFile.xml", publisher.getSourceDataFiles());
         assertEquals(15, publisher.getErrorFailedThreshold());
         assertEquals(16, publisher.getErrorUnstableThreshold());
@@ -357,13 +357,13 @@ public class PerformancePublisherTest extends HudsonTestCase {
         assertEquals(allConstraints, publisher.getConstraints());
 
         publisher = new PerformancePublisher("reportFile.xml", 15, 16, "reportFile.xml:100", 9.0, 8.0, 7.0, 6.0, 3, true, "MRT",
-                true, true, true, true, null);
+                true, true, true, true,false, null);
         assertTrue(publisher.isMRT());
         publisher = new PerformancePublisher("reportFile.xml", 15, 16, "reportFile.xml:100", 9.0, 8.0, 7.0, 6.0, 3, true, "ART",
-                true, true, true, true, null);
+                true, true, true, true,false, null);
         assertTrue(publisher.isART());
         publisher = new PerformancePublisher("reportFile.xml", 15, 16, "reportFile.xml:100", 9.0, 8.0, 7.0, 6.0, 3, true, "PRT",
-                true, true, true, true, null);
+                true, true, true, true,false, null);
         assertTrue(publisher.isPRT());
 
         publisher.setFilename("testfilename");
@@ -382,7 +382,7 @@ public class PerformancePublisherTest extends HudsonTestCase {
                 1,  // errorUnstableThreshold
                 "", 0.0, 0.0, 0.0, 0.0, 1, true, "MRT",
                 false, // modeOfThreshold (false = Error Threshold)
-                true, true, true, null);
+                true, true, true,false, null);
 
         FreeStyleProject project = createFreeStyleProject();
 
@@ -406,10 +406,10 @@ public class PerformancePublisherTest extends HudsonTestCase {
     public void testErrorThresholdFailed() throws Exception {
 
         PerformancePublisher publisherFailed = new PerformancePublisher("JMeterPublisher.csv",
-                 2, //errorFailedThreshold
+                2, //errorFailedThreshold
                 -1, "", 0.0, 0.0, 0.0, 0.0, 1, true, "MRT",
                 false, // modeOfThreshold (false = Error Threshold)
-                true, true, true, null);
+                true, true, true,false, null);
 
         FreeStyleProject project = createFreeStyleProject();
 
@@ -435,7 +435,7 @@ public class PerformancePublisherTest extends HudsonTestCase {
         PerformancePublisher publisherART = new PerformancePublisher("JMeterPublisher.csv", -1, -1,
                 "JMeterPublisher.csv:1000", 0.0, 0.0, 0.0, 0.0, 1, true, "MRT",
                 false, // modeOfThreshold (false = Error Threshold)
-                true, true, true, null);
+                true, true, true,false, null);
 
         FreeStyleProject project = createFreeStyleProject();
 
@@ -471,7 +471,7 @@ public class PerformancePublisherTest extends HudsonTestCase {
         parsers.add(new JMeterCsvParser("test1", PerformanceReportTest.DEFAULT_PERCENTILES));
         parsers.add(new JMeterParser("test2", PerformanceReportTest.DEFAULT_PERCENTILES));
 
-        PerformancePublisher publisher = new PerformancePublisher("", -1, -1, "", 0.0, 0.0, 0.0, 0.0, 1, true, "MRT", false, true, true, true, parsers);
+        PerformancePublisher publisher = new PerformancePublisher("", -1, -1, "", 0.0, 0.0, 0.0, 0.0, 1, true, "MRT", false, true, true, true,false, parsers);
 
         assertEquals("test1;test2", publisher.getSourceDataFiles());
         assertNull(publisher.getParsers());
@@ -494,7 +494,7 @@ public class PerformancePublisherTest extends HudsonTestCase {
                 5.0, // relativeUnstableThresholdNegative
                 1, true, "MRT",
                 true, // modeOfThreshold (true = Relative Threshold)
-                true, true, true, null);
+                true, true, true,false, null);
 
         p.getPublishersList().add(publisher);
         // first build
@@ -528,7 +528,7 @@ public class PerformancePublisherTest extends HudsonTestCase {
                 -0.1, // relativeUnstableThresholdNegative
                 1, true, "ART",
                 true, // modeOfThreshold (true = Relative Threshold)
-                true, true, true, null);
+                true, true, true,false, null);
 
         p.getPublishersList().add(publisher);
         // first build
@@ -562,7 +562,7 @@ public class PerformancePublisherTest extends HudsonTestCase {
                 -0.1, -0.1, 1, true, "PRT",
                 true, // modeOfThreshold (true = Relative Threshold)
                 true, false, // false - means compare with Build Number
-                true, null);
+                true,false, null);
 
         p.getPublishersList().add(publisher);
         // first build
@@ -596,7 +596,7 @@ public class PerformancePublisherTest extends HudsonTestCase {
                 -0.1, -0.1, -0.1, 1, true, "PRT",
                 true, // modeOfThreshold (true = Relative Threshold)
                 true, false, // false - means compare with Build Number
-                true, null);
+                true,false, null);
 
         p.getPublishersList().add(publisher);
         // first build

--- a/src/test/java/hudson/plugins/performance/PerformanceReportMapTest.java
+++ b/src/test/java/hudson/plugins/performance/PerformanceReportMapTest.java
@@ -51,6 +51,7 @@ public class PerformanceReportMapTest extends AbstractGraphGenerationTest {
         PerformanceReportMap reportMap = new PerformanceReportMap(performanceBuildAction, mock(TaskListener.class));
         assertTrue(reportMap.ifModeThroughputUsed());
         assertFalse(reportMap.ifModePerformancePerTestCaseUsed());
+        assertFalse(reportMap.ifShowTrendGraphsUsed());
         assertEquals(performanceBuildAction, reportMap.getBuildAction());
         assertEquals("Performance", reportMap.getDisplayName());
         assertEquals("performance", reportMap.getUrlName());

--- a/src/test/java/hudson/plugins/performance/actions/PerformanceProjectActionTest.java
+++ b/src/test/java/hudson/plugins/performance/actions/PerformanceProjectActionTest.java
@@ -53,7 +53,7 @@ public class PerformanceProjectActionTest {
         assertFalse(performanceProjectAction.ifModePerformancePerTestCaseUsed());
         assertTrue(performanceProjectAction.ifModeThroughputUsed());
 
-        freeStyleProject.getPublishersList().add(new PerformancePublisher("", 0, 0, "", 0.0, 0.0, 0.0, 0.0, 0, false, "", true, false, false, true, null));
+        freeStyleProject.getPublishersList().add(new PerformancePublisher("", 0, 0, "", 0.0, 0.0, 0.0, 0.0, 0, false, "", true, false, false, true,false, null));
         assertFalse(performanceProjectAction.ifModePerformancePerTestCaseUsed());
         assertTrue(performanceProjectAction.ifModeThroughputUsed());
     }

--- a/src/test/java/hudson/plugins/performance/constraints/ConstraintTest.java
+++ b/src/test/java/hudson/plugins/performance/constraints/ConstraintTest.java
@@ -52,7 +52,7 @@ public class ConstraintTest {
         List<AbstractConstraint> abstractBuildsList = new ArrayList<AbstractConstraint>();
         abstractBuildsList.add(absoluteConstraint);
 
-        PerformancePublisher performancePublisher = new PerformancePublisher("", 10, 20, "", 0, 0, 0, 0, 0, false, "", false, true, false, true, null);
+        PerformancePublisher performancePublisher = new PerformancePublisher("", 10, 20, "", 0, 0, 0, 0, 0, false, "", false, true, false, true,false, null);
         performancePublisher.setModeEvaluation(true);
         performancePublisher.setConstraints(abstractBuildsList);
         performancePublisher.setIgnoreFailedBuilds(false);
@@ -96,7 +96,7 @@ public class ConstraintTest {
         abstractBuildsList.add(absoluteConstraint);
 
 
-        PerformancePublisher performancePublisher = new PerformancePublisher("testResult.xml", 10, 20, "", 0, 0, 0, 0, 0, false, "", false, true, false, true, null);
+        PerformancePublisher performancePublisher = new PerformancePublisher("testResult.xml", 10, 20, "", 0, 0, 0, 0, 0, false, "", false, true, false, true,false, null);
         performancePublisher.setModeEvaluation(true);
         performancePublisher.setConstraints(abstractBuildsList);
         performancePublisher.setIgnoreFailedBuilds(false);
@@ -138,7 +138,7 @@ public class ConstraintTest {
         List<AbstractConstraint> abstractBuildsList = new ArrayList<AbstractConstraint>();
         abstractBuildsList.add(absoluteConstraint);
 
-        PerformancePublisher performancePublisher = new PerformancePublisher(getClass().getResource("/constraint-test.xml").getFile(), 10, 20, "", 0, 0, 0, 0, 0, false, "", false, true, false, true, null);
+        PerformancePublisher performancePublisher = new PerformancePublisher(getClass().getResource("/constraint-test.xml").getFile(), 10, 20, "", 0, 0, 0, 0, 0, false, "", false, true, false, true,false, null);
         performancePublisher.setModeEvaluation(true);
         performancePublisher.setConstraints(abstractBuildsList);
         performancePublisher.setIgnoreFailedBuilds(false);
@@ -180,7 +180,7 @@ public class ConstraintTest {
         List<AbstractConstraint> abstractBuildsList = new ArrayList<AbstractConstraint>();
         abstractBuildsList.add(absoluteConstraint);
 
-        PerformancePublisher performancePublisher = new PerformancePublisher("", 10, 20, "", 0, 0, 0, 0, 0, false, "", false, true, false, true, null);
+        PerformancePublisher performancePublisher = new PerformancePublisher("", 10, 20, "", 0, 0, 0, 0, 0, false, "", false, true, false, true,false, null);
         performancePublisher.setModeEvaluation(true);
         performancePublisher.setConstraints(abstractBuildsList);
         performancePublisher.setIgnoreFailedBuilds(false);
@@ -223,7 +223,7 @@ public class ConstraintTest {
         List<AbstractConstraint> abstractBuildsList = new ArrayList<AbstractConstraint>();
         abstractBuildsList.add(absoluteConstraint);
 
-        PerformancePublisher performancePublisher = new PerformancePublisher(getClass().getResource("/constraint-test.xml").getFile(), 10, 20, "", 0, 0, 0, 0, 0, false, "", false, true, false, true, null);
+        PerformancePublisher performancePublisher = new PerformancePublisher(getClass().getResource("/constraint-test.xml").getFile(), 10, 20, "", 0, 0, 0, 0, 0, false, "", false, true, false, true,false, null);
         performancePublisher.setModeEvaluation(true);
         performancePublisher.setConstraints(abstractBuildsList);
         performancePublisher.setIgnoreFailedBuilds(false);
@@ -265,7 +265,7 @@ public class ConstraintTest {
         List<AbstractConstraint> abstractBuildsList = new ArrayList<AbstractConstraint>();
         abstractBuildsList.add(absoluteConstraint);
 
-        PerformancePublisher performancePublisher = new PerformancePublisher(getClass().getResource("/constraint-test.xml").getFile(), 10, 20, "", 0, 0, 0, 0, 0, false, "", false, true, false, true, null);
+        PerformancePublisher performancePublisher = new PerformancePublisher(getClass().getResource("/constraint-test.xml").getFile(), 10, 20, "", 0, 0, 0, 0, 0, false, "", false, true, false, true,false, null);
         performancePublisher.setModeEvaluation(true);
         performancePublisher.setConstraints(abstractBuildsList);
         performancePublisher.setIgnoreFailedBuilds(false);
@@ -307,7 +307,7 @@ public class ConstraintTest {
         List<AbstractConstraint> abstractBuildsList = new ArrayList<AbstractConstraint>();
         abstractBuildsList.add(absoluteConstraint);
 
-        PerformancePublisher performancePublisher = new PerformancePublisher("", 10, 20, "", 0, 0, 0, 0, 0, false, "", false, true, false, true, null);
+        PerformancePublisher performancePublisher = new PerformancePublisher("", 10, 20, "", 0, 0, 0, 0, 0, false, "", false, true, false, true,false, null);
         performancePublisher.setModeEvaluation(true);
         performancePublisher.setConstraints(abstractBuildsList);
         performancePublisher.setIgnoreFailedBuilds(false);
@@ -350,7 +350,7 @@ public class ConstraintTest {
         List<AbstractConstraint> abstractBuildsList = new ArrayList<AbstractConstraint>();
         abstractBuildsList.add(absoluteConstraint);
 
-        PerformancePublisher performancePublisher = new PerformancePublisher("", 10, 20, "", 0, 0, 0, 0, 0, false, "", false, true, false, true, null);
+        PerformancePublisher performancePublisher = new PerformancePublisher("", 10, 20, "", 0, 0, 0, 0, 0, false, "", false, true, false, true,false, null);
         performancePublisher.setModeEvaluation(true);
         performancePublisher.setConstraints(abstractBuildsList);
         performancePublisher.setIgnoreFailedBuilds(false);
@@ -393,7 +393,7 @@ public class ConstraintTest {
         List<AbstractConstraint> abstractBuildsList = new ArrayList<AbstractConstraint>();
         abstractBuildsList.add(absoluteConstraint);
 
-        PerformancePublisher performancePublisher = new PerformancePublisher(getClass().getResource("/constraint-test.xml").getFile(), 10, 20, "", 0, 0, 0, 0, 0, false, "", false, true, false, true, null);
+        PerformancePublisher performancePublisher = new PerformancePublisher(getClass().getResource("/constraint-test.xml").getFile(), 10, 20, "", 0, 0, 0, 0, 0, false, "", false, true, false, true,false, null);
         performancePublisher.setModeEvaluation(true);
         performancePublisher.setConstraints(abstractBuildsList);
         performancePublisher.setIgnoreFailedBuilds(false);


### PR DESCRIPTION
This implementation is to provide user an option to enable or disable trend graphs within performance report through Performance Plugin

Ticket ID : [JENKINS-64638]

![image-20201201-074421](https://user-images.githubusercontent.com/54930157/104737532-61916300-576a-11eb-926c-02e89f073053.png)

When Enabled:

![image-20201201-130237](https://user-images.githubusercontent.com/54930157/104737887-d795ca00-576a-11eb-9310-bc42a0eece8e.png)

When Disabled:

![image-20201201-130408](https://user-images.githubusercontent.com/54930157/104737940-e5e3e600-576a-11eb-9d02-2cca82f80eef.png)

