### PR TITLE
Added the posibillity to explicitly set the path to 'virtualenv'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ jdk:
 #- sudo apt-get install python3.6-pip
 install:
 - pyenv global 3.6
+- pip3 install --upgrade pip
 - pip3 install bzt --user
 - "mvn -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Djenkins.version=1.642.3 -Dmaven.test.skip=true clean install --batch-mode -e"
 script: "mvn -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Djava.awt.headless=true -Dmaven.test.redirectTestOutputToFile=true -Dcobertura.report.format=xml --fail-at-end --batch-mode cobertura:cobertura test"

--- a/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
+++ b/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
@@ -85,6 +85,7 @@ public class PerformanceTestBuild extends Builder implements SimpleBuildStep {
     private boolean useBztExitCode = true;
     private String bztVersion = "";
     private String workingDirectory = "";
+    private String virtualEnvCommand = "";
     /**
      * Use 'workingDirectory' for set bzt working directory
      */
@@ -411,7 +412,14 @@ public class PerformanceTestBuild extends Builder implements SimpleBuildStep {
         return new String[]{getVirtualenvPath(workspace) + "bzt", HELP_OPTION};
     }
 
+    private String getVirtualEnvCommand(EnvVars envVars) {
+        return virtualEnvCommand == null || virtualEnvCommand.trim().isEmpty() ? VIRTUALENV_COMMAND : envVars.expand(virtualEnvCommand);s
+    }
+
     public int runCmd(String[] commands, FilePath workspace, OutputStream logger, Launcher launcher, EnvVars envVars) throws InterruptedException, IOException {
+        if (commands[0].equals(VIRTUALENV_COMMAND)) {
+            commands[0] = getVirtualEnvCommand(envVars);
+        }
         try {
             return launcher.launch().cmds(commands).envs(envVars).stdout(logger).stderr(logger).pwd(workspace).start().join();
         } catch (IOException ex) {
@@ -508,5 +516,14 @@ public class PerformanceTestBuild extends Builder implements SimpleBuildStep {
     @DataBoundSetter
     public void setWorkingDirectory(String workingDirectory) {
         this.workingDirectory = workingDirectory;
+    }
+
+    public String getVirtualEnvCommand() {
+        return virtualEnvCommand;
+    }
+
+    @DataBoundSetter
+    public void setVirtualEnvCommand(String virtualEnvCommand) {
+        this.virtualEnvCommand = virtualEnvCommand;
     }
 }

--- a/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
+++ b/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
@@ -413,7 +413,7 @@ public class PerformanceTestBuild extends Builder implements SimpleBuildStep {
     }
 
     private String getVirtualEnvCommand(EnvVars envVars) {
-        return virtualEnvCommand == null || virtualEnvCommand.trim().isEmpty() ? VIRTUALENV_COMMAND : envVars.expand(virtualEnvCommand);s
+        return virtualEnvCommand == null || virtualEnvCommand.trim().isEmpty() ? VIRTUALENV_COMMAND : envVars.expand(virtualEnvCommand);
     }
 
     public int runCmd(String[] commands, FilePath workspace, OutputStream logger, Launcher launcher, EnvVars envVars) throws InterruptedException, IOException {

--- a/src/main/resources/hudson/plugins/performance/build/PerformanceTestBuild/config.jelly
+++ b/src/main/resources/hudson/plugins/performance/build/PerformanceTestBuild/config.jelly
@@ -5,6 +5,9 @@
     </f:entry>
 
     <f:advanced>
+        <f:entry title="${%VEnv path}" field="virtualEnvCommand" >
+            <f:textbox />
+        </f:entry>
         <f:entry title="${%Change workingDirectory}" field="workingDirectory" >
             <f:textbox />
         </f:entry>

--- a/src/main/resources/hudson/plugins/performance/build/PerformanceTestBuild/config.properties
+++ b/src/main/resources/hudson/plugins/performance/build/PerformanceTestBuild/config.properties
@@ -1,4 +1,5 @@
 Test\ params=Taurus tool parameters:
+VEnv\ path=Path to \''virtualenv\'' binary (if empty, it should be in $PATH):
 Change\ workingDirectory=Change working directory:
 Auto\ report=Automatically generate performance report
 Use\ bzt\ code=Mark build unstable/failed based on exit code

--- a/src/test/java/hudson/plugins/performance/build/PerformanceTestBuildTest.java
+++ b/src/test/java/hudson/plugins/performance/build/PerformanceTestBuildTest.java
@@ -404,8 +404,14 @@ public class PerformanceTestBuildTest extends HudsonTestCase {
         assertTrue(jobLog, jobLog.contains("Cannot create working directory because of error: Failed to mkdirs: /rootWorkspace"));
     }
 
+    private void resetVirtualEnvCommands() {
+        PerformanceTestBuild.CHECK_VIRTUALENV_COMMAND[0] = PerformanceTestBuild.VIRTUALENV_COMMAND;
+        PerformanceTestBuild.CREATE_LOCAL_PYTHON_COMMAND_WITH_SYSTEM_PACKAGES_OPTION[0] = PerformanceTestBuild.VIRTUALENV_COMMAND;
+        PerformanceTestBuild.CREATE_LOCAL_PYTHON_COMMAND[0] = PerformanceTestBuild.VIRTUALENV_COMMAND;
+    }
     @Test
     public void testDefaultVirtualEnvCommand() throws Exception {
+        resetVirtualEnvCommands();
         String path = getClass().getResource("/performanceTest.yml").getPath();
 
         FreeStyleProject project = createFreeStyleProject();
@@ -438,11 +444,14 @@ public class PerformanceTestBuildTest extends HudsonTestCase {
 
         assertEquals(jobLog, Result.SUCCESS, buildExt.getResult());
         assertEquals(jobLog, 5, buildTest.commands.size());
-        assertTrue(buildTest.commands.get(0)[0], buildTest.commands.get(0)[0].equals("virtualenv"));
+        assertTrue("Command should have been 'virtualenv', but instead it was: '" + buildTest.commands.get(0)[0] + "'",
+                buildTest.commands.get(0)[0].equals("virtualenv"));
+        resetVirtualEnvCommands();
     }
 
     @Test
     public void testHardcodedVirtualEnvCommand() throws Exception {
+        resetVirtualEnvCommands();
         String path = getClass().getResource("/performanceTest.yml").getPath();
 
         FreeStyleProject project = createFreeStyleProject();
@@ -476,11 +485,14 @@ public class PerformanceTestBuildTest extends HudsonTestCase {
 
         assertEquals(jobLog, Result.SUCCESS, buildExt.getResult());
         assertEquals(jobLog, 5, buildTest.commands.size());
-        assertTrue(buildTest.commands.get(0)[0], buildTest.commands.get(0)[0].equals("/path/to/virtualenv"));
+        assertTrue("Command should have been '/path/to/virtualenv', but instead it was: '" + buildTest.commands.get(0)[0] + "'",
+                buildTest.commands.get(0)[0].equals("/path/to/virtualenv"));
+        resetVirtualEnvCommands();
     }
 
     @Test
     public void testVariableVirtualEnvCommand() throws Exception {
+        resetVirtualEnvCommands();
         String path = getClass().getResource("/performanceTest.yml").getPath();
 
         FreeStyleProject project = createFreeStyleProject();
@@ -514,6 +526,8 @@ public class PerformanceTestBuildTest extends HudsonTestCase {
 
         assertEquals(jobLog, Result.SUCCESS, buildExt.getResult());
         assertEquals(jobLog, 5, buildTest.commands.size());
-        assertTrue(buildTest.commands.get(0)[0], buildTest.commands.get(0)[0].equals(workspace + "/virtualenv"));
+        assertTrue("Command should have been '" + workspace + "/virtualenv', but instead it was: '" + buildTest.commands.get(0)[0] + "'",
+                buildTest.commands.get(0)[0].equals(workspace + "/virtualenv"));
+        resetVirtualEnvCommands();
     }
 }


### PR DESCRIPTION
On our machines, we are installing 'python' and 'virtualenv' using the Custom Tools in Jenkins. They should change the PATH environment, but unfortunately the plugin does not pick up this changes path (I believe it is a known bug in Jenkins -- will try to find the issue).
I added a parameter (in the advanced block of the build, because it is not necessary to set this parameter) to set the path to the virtualenv-binary to use. I made it possible to use EnvVar to set the path, because not all our machines are installed in the same path (eg Linux vs Windows) and I would like to be able to have a single configuration to work on all our machines.