### PR TITLE
[JENKINS-64990] tables-to-divs: compatibility with Jenkins 2.264+

### DIFF
--- a/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:p="/lib/performance">
 
   <f:entry title="${%Source files}" field="sourceDataFiles">
     <f:textbox />
@@ -15,160 +15,120 @@
 
   <f:entry title="Select evaluation mode" field="modeEvaluation">
     <f:booleanRadio name="modeEvaluation"  false="Standard Mode" true="Expert Mode" />
-  </f:entry> 
+  </f:entry>
 
   <f:entry>
-    <table style="border:1;border-style:solid">
+    <p:blockWrapper style="border:1;border-style:solid;" divStyle="margin-left:50px; padding-left:6px; padding-right:6px;">
       <p><b>Standard Mode</b></p>
-      <f:entry title="Select mode:   ">
-        <f:booleanRadio name="modeOfThreshold" field="modeOfThreshold" true="Relative Threshold" false="Error Threshold" />
-      </f:entry>
-
       <f:block>
-        <f:entry title="Use Error thresholds on single build:   ">
-          <table width="500px">
-            <tr>
-              <td>
-                <label>${%Unstable}</label>
-              </td>
-              <td>
-                <f:textbox field="errorUnstableThreshold" default="-1"/>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <label>${%Failed}</label>
-              </td>
-              <td>
-                <f:textbox field="errorFailedThreshold" default="-1"/>
-              </td>
-            </tr>
-          </table>
+        <f:radioBlock name="_.modeOfThreshold" field="modeOfThreshold" value="false" title="Error Threshold" checked="${!instance.getModeOfThreshold()}" inline="true" help="${null}">
+          <f:entry title="Use Error thresholds on single build:   ">
+            <p:blockWrapper>
+              <f:block>
+                <f:entry title="${%Unstable}">
+                  <f:textbox field="errorUnstableThreshold" default="-1"/>
+                </f:entry>
+                <f:entry title="${%Failed}">
+                  <f:textbox field="errorFailedThreshold" default="-1"/>
+                </f:entry>
+                <f:advanced>
+                  <f:entry title="${%Average response time threshold}" field="errorUnstableResponseTimeThreshold">
+                    <f:textarea style="height:100px;"/>
+                  </f:entry>
+                </f:advanced>
+              </f:block>
+            </p:blockWrapper>
+          </f:entry>
+        </f:radioBlock>
+        <f:radioBlock name="_.modeOfThreshold" field="modeOfThreshold" value="true" title="Relative Threshold" checked="${instance.getModeOfThreshold()}" inline="true" help="${null}">
+          <f:entry title="Use Relative thresholds for build comparison:   ">
+            <p:blockWrapper>
+              <f:block>
+                <table cellspacing="5">
+                  <tr>
+                    <td width="25%">
+                      <label> </label>
+                    </td>
+                    <td width="20%" align="center">
+                      <label>(-)</label>
+                    </td>
+                    <td width="20%" align="center">
+                      <label>(+)</label>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td width="25%">
+                      <label>Unstable % Range</label>
+                    </td>
+                    <td>
+                      <f:number field="relativeUnstableThresholdNegative" default="-1.0"/>
+                    </td>
+                    <td>
+                      <f:number field="relativeUnstableThresholdPositive" default="-1.0"/>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td width="25%">
+                      <label>Failed % Range</label>
+                    </td>
+                    <td>
+                      <f:number field="relativeFailedThresholdNegative" default="-1.0"/>
+                    </td>
+                    <td>
+                      <f:number field="relativeFailedThresholdPositive" default="-1.0"/>
+                    </td>
+                  </tr>
+                </table>
+                <f:radioBlock name="_.compareBuildPrevious" field="compareBuildPrevious" value="true" title="Compare with previous Build" checked="${instance.getCompareBuildPrevious()}" inline="true">
+                </f:radioBlock>
+                <f:radioBlock name="_.compareBuildPrevious" field="compareBuildPrevious" value="false" title="Compare with Build number" checked="${!instance.getCompareBuildPrevious()}" inline="true">
+                  <f:entry title="Build number">
+                    <f:number field="nthBuildNumber"/>
+                  </f:entry>
+                </f:radioBlock>
+                <f:entry title="${%Compare based on}" field="configType" name="configType">
+                  <f:select name="configType">
+                    <option value="ART">Average Response Time</option>
+                    <option value="MRT">Median Response Time</option>
+                    <option value="PRT">90% ResponseTime</option>
+                  </f:select>
+                </f:entry>
+              </f:block>
+            </p:blockWrapper>
+          </f:entry>
+        </f:radioBlock>
+      </f:block>
+    </p:blockWrapper>
+  </f:entry>
+
+  <f:entry>
+    <p:blockWrapper style="border:1;border-style:solid;" divStyle="margin-left:50px; padding-left:6px; padding-right:6px;">
+      <p><b>Expert Mode</b></p>
+      <f:block>
+        <f:entry title="Constraint settings">
+          <f:entry>
+            <f:checkbox name="ignoreFailedBuilds" title="Ignore Failed Builds"  checked="${instance.isIgnoreFailedBuilds()}"/>
+          </f:entry>
+          <f:entry>
+            <f:checkbox name="ignoreUnstableBuilds" title="Ignore Unstable Builds" field="ignoreUnstableBuilds" checked="${instance.isIgnoreUnstableBuilds()}"/>
+          </f:entry>
+          <f:entry>
+            <f:checkbox name="persistConstraintLog" title="Save constraint log to workspace"  checked="${instance.isPersistConstraintLog()}"/>
+          </f:entry>
         </f:entry>
 
-        <f:advanced>
-          <f:entry title="${%Average response time threshold}" field="errorUnstableResponseTimeThreshold">
-            <table>
-              <tbody>
-                <tr>
-                  <td>
-                    <f:textarea style="width:600px;height:100px;"/>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </f:entry>
-        </f:advanced>
+        <f:entry title="${%JUnit output file}">
+          <f:textbox name="junitOutput" field="junitOutput" default=""/>
+        </f:entry>
 
-        <f:entry title="Use Relative thresholds for build comparison:   ">
-          <table width="500px" cellspacing="5">
-            <tr>
-              <td width="25%">
-                <label> </label>
-              </td>
-              <td width="20%" align="center">
-                <label>(-)</label>
-              </td>
-              <td width="20%" align="center">
-                <label>(+)</label>
-              </td>
-            </tr>
-            <tr>
-              <td width="25%">
-                <label>Unstable % Range</label>
-              </td>
-              <td>
-                <f:number field="relativeUnstableThresholdNegative" default="-1.0"/>
-              </td>
-              <td>
-                <f:number field="relativeUnstableThresholdPositive" default="-1.0"/>
-              </td>
-            </tr>
-            <tr>
-              <td width="25%">
-                <label>Failed % Range</label>
-              </td>
-              <td>
-                <f:number field="relativeFailedThresholdNegative" default="-1.0"/>
-              </td>
-              <td>
-                <f:number field="relativeFailedThresholdPositive" default="-1.0"/>
-              </td>
-            </tr>
-            <tr>
-              <td colspan="3">
-                <table>
-                  <tr>
-                    <td width="85%">
-                      <f:booleanRadio name="compareBuildPrevious" field="compareBuildPrevious" true="Compare with previous Build" false="Compare with Build number" />
-                    </td>
-                    <td width="15%">
-                      <f:number field="nthBuildNumber"/>
-                    </td>
-                  </tr>
-                </table>
-              </td>
-            </tr>
-            <tr>
-              <td width="25%">
-                <label>${%Compare based on}</label>
-              </td>
-              <td colspan="2">
-                <table>
-                  <tr>
-                    <f:entry field="configType" name="configType">
-                      <f:select name="configType">
-                        <option value="ART">Average Response Time</option>
-                        <option value="MRT">Median Response Time</option>
-                        <option value="PRT">90% ResponseTime</option>
-                      </f:select>
-                    </f:entry>
-                  </tr>
-                </table>
-              </td>
-            </tr>
-          </table>
+        <f:entry title="Constraints" field="constraints">
+          <f:hetero-list name="constraints" hasHeader="true"
+                     descriptors="${descriptor.getConstraintDescriptors()}"
+                     items="${instance.constraints}"
+                     addCaption="${%Add a new constraint}"/>
         </f:entry>
       </f:block>
-    </table>
-  </f:entry>                 
-  
-  <f:entry>
-    <table style="border:1;border-style:solid">
-      <p><b>Expert Mode</b></p>
-      <f:entry title="Constraint settings">
-        <table width="500px">
-          <tbody>
-            <tr>
-              <td>
-                <f:checkbox name="ignoreFailedBuilds" title="Ignore Failed Builds"  checked="${instance.isIgnoreFailedBuilds()}"/>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <f:checkbox name="ignoreUnstableBuilds" title="Ignore Unstable Builds" field="ignoreUnstableBuilds" checked="${instance.isIgnoreUnstableBuilds()}"/>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <f:checkbox name="persistConstraintLog" title="Save constraint log to workspace"  checked="${instance.isPersistConstraintLog()}"/>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </f:entry>
-
-      <f:entry title="${%JUnit output file}">
-        <f:textbox name="junitOutput" field="junitOutput" default=""/>
-      </f:entry>
-  
-  <f:entry title="Constraints" field="constraints">
-    <f:hetero-list name="constraints" hasHeader="true"
-                   descriptors="${descriptor.getConstraintDescriptors()}"
-                   items="${instance.constraints}"
-                   addCaption="${%Add a new constraint}"/>
-      </f:entry>
-    </table>
+    </p:blockWrapper>
   </f:entry>
 
   <f:advanced>
@@ -185,41 +145,30 @@
     </f:entry>
 
     <f:entry title="${%Performance display}">
-      <table>
-        <tbody>
-          <tr>
-            <td>
-              <f:checkbox name="modePerformancePerTestCase" title="Display Performance Report Per Test Case" field="modePerformancePerTestCase">
-                Display Performance Report Per Test Case
-              </f:checkbox>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <f:checkbox name="modeThroughput" title="Display Performance Report with Throughput (requests per second)" field="modeThroughput">
-                Display Performance Report with Throughput (requests per second)
-              </f:checkbox>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <f:checkbox name="excludeResponseTime" title="Exclude response time of errored samples" field="excludeResponseTime">
-                Exclude response time of errored samples
-              </f:checkbox>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <f:checkbox name="failBuildIfNoResultFile" title="Fail build when result files are not present" default="true" field="failBuildIfNoResultFile">
-                Fail build when result files are not present
-              </f:checkbox>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <f:entry>
+        <f:checkbox name="modePerformancePerTestCase" title="Display Performance Report Per Test Case" field="modePerformancePerTestCase">
+          Display Performance Report Per Test Case
+        </f:checkbox>
+      </f:entry>
+      <f:entry>
+        <f:checkbox name="modeThroughput" title="Display Performance Report with Throughput (requests per second)" field="modeThroughput">
+          Display Performance Report with Throughput (requests per second)
+        </f:checkbox>
+      </f:entry>
+      <f:entry>
+        <f:checkbox name="excludeResponseTime" title="Exclude response time of errored samples" field="excludeResponseTime">
+          Exclude response time of errored samples
+        </f:checkbox>
+      </f:entry>
+      <f:entry>
+        <f:checkbox name="failBuildIfNoResultFile" title="Fail build when result files are not present" default="true" field="failBuildIfNoResultFile">
+          Fail build when result files are not present
+        </f:checkbox>
+      </f:entry>
     </f:entry>
     <f:entry title="Baseline build number">
       <f:number name="baselineBuild" field="baselineBuild" />
     </f:entry>
   </f:advanced>
+
 </j:jelly>

--- a/src/main/resources/hudson/plugins/performance/constraints/AbsoluteConstraint/config.jelly
+++ b/src/main/resources/hudson/plugins/performance/constraints/AbsoluteConstraint/config.jelly
@@ -1,80 +1,77 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-	
-	<f:block>
-		
-	<f:entry title="Define Absolute Constraint:   ">
-      <table width="500" cellspacing="0" border="0px">
-      	<tr>
-            <f:block>
-  				<table>
-      					<f:entry field="relatedPerfReport">
-       						<label> Related Report </label><f:textbox name="relatedPerfReport"/>
-      					</f:entry>
- 				</table>
-			</f:block>
-        </tr>
-        <tr>
-            <f:block>
-  				<table>
-    				<f:optionalBlock name="testCaseBlock" title="Specify a test case" checked="${instance.getTestCaseBlock() != null}">
-      					<f:entry field="testCase">
-       						<f:textbox name="testCase"/>
-      					</f:entry>
-    				</f:optionalBlock>
- 				</table>
-			</f:block>
-        </tr>
-        <tr>
-        	<td width="25%" align="center">
-            	<label> Metric </label>
-          	</td>
-          	<td width="30%" align="center">
-        		<label> Operator </label>
-          	</td>
-          	<td width="15%" align="center">
-       			<label> Value </label>
-          	</td>
-          	<td width="30%" align="center">
-        		<label> Escalation </label>
-          	</td>
-        </tr>
-        <tr>
-        	<td style="vertical-align: middle">
-        		<table>
-          			<tr>
-          				<f:entry field="meteredValue" name="meteredValue">
-          					<f:enum>${it}</f:enum>
-          				</f:entry>
-          			</tr>
-          		</table>
-        	</td>
-        	<td style="vertical-align: middle">
-        		<table>
-        			<tr>
-        				<f:entry field="operator" name="operator">
-        					<f:enum>${it}</f:enum>
-          				</f:entry>
-        			</tr>
-        		</table>
-        	</td>
-        	<td style="vertical-align: middle">
-        		<f:number field="value" name="value" default="0" min="0"/>
-        	</td>
-        	<td style="vertical-align: middle">
-        		<table>
-        			<tr>
-        				<f:entry field="escalationLevel" name="escalationLevel">
-        					<f:enum>${it}</f:enum>
-          				</f:entry>
-        			</tr>
-        		</table>
-        	</td>	
-        </tr>	
-      </table>
-     </f:entry>
-		
-	</f:block>
-  
-
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:p="/lib/performance">
+  <f:block>
+    <f:entry>
+      <p:blockWrapper tableStyle="width: 500px; cellspacing:0; border:0px;">
+        <f:block>
+          <f:entry title="Related Report" field="relatedPerfReport">
+            <f:textbox name="relatedPerfReport"/>
+          </f:entry>
+        </f:block>
+        <f:block>
+          <f:optionalBlock name="testCaseBlock" title="Specify a test case" checked="${instance.getTestCaseBlock() != null}">
+            <f:entry field="testCase">
+              <f:textbox name="testCase"/>
+            </f:entry>
+          </f:optionalBlock>
+        </f:block>
+        <f:block>
+          <table>
+            <tr>
+              <td width="25%" align="center">
+                <label> Metric </label>
+              </td>
+              <td width="30%" align="center">
+                <label> Operator </label>
+              </td>
+              <td width="15%" align="center">
+                <label> Value </label>
+              </td>
+              <td width="30%" align="center">
+                <label> Escalation </label>
+              </td>
+            </tr>
+            <tr>
+              <td style="vertical-align: middle">
+                <table>
+                  <tr>
+                    <f:entry field="meteredValue" name="meteredValue">
+                      <f:enum>${it}</f:enum>
+                    </f:entry>
+                  </tr>
+                </table>
+              </td>
+              <td style="vertical-align: middle">
+                <table>
+                  <tr>
+                    <f:entry field="operator" name="operator">
+                      <f:enum>${it}</f:enum>
+                    </f:entry>
+                  </tr>
+                </table>
+              </td>
+              <td style="vertical-align: middle">
+                <table>
+                  <tr>
+                    <f:entry field="value" name="value">
+                      <f:number field="value" name="value" default="0" min="0"/>
+                    </f:entry>
+                  </tr>
+                </table>
+              </td>
+              <td style="vertical-align: middle">
+                <table>
+                  <tr>
+                    <f:entry field="escalationLevel" name="escalationLevel">
+                      <f:enum>${it}</f:enum>
+                    </f:entry>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </f:block>
+      </p:blockWrapper>
+    </f:entry>
+  </f:block>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/performance/constraints/RelativeConstraint/config.jelly
+++ b/src/main/resources/hudson/plugins/performance/constraints/RelativeConstraint/config.jelly
@@ -1,159 +1,106 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-		
-	<f:block>
-		
-	<f:entry title="Define Relative Constraint:   ">
-      <table width="500" cellspacing="0" border="0px">
-      	<tr>
-            <f:block>
-  				<table>
-      					<f:entry field="relatedPerfReport">
-       						<label> Related Report ${radioId3}</label><f:textbox name="relatedPerfReport"/>
-      					</f:entry>
- 				</table>
-			</f:block>
-        </tr>
-        <tr>
-            <f:block>
-  				<table>
-    				<f:optionalBlock name="testCaseBlock" title="Specify a test case" checked="${instance.getTestCaseBlock() != null}">
-      					<f:entry field="testCase">
-       						<f:textbox name="testCase"/>
-      					</f:entry>
-    				</f:optionalBlock>
- 				</table>
-			</f:block>
-        </tr>
-        <tr>
-        	<td width="25%" align="center">
-            	<label> Metric </label>
-          	</td>
-          	<td width="30%" align="center">
-        		<label> Operator </label>
-          	</td>
-          	<td width="15%" align="center">
-       			<label> Tolerance-%</label>
-          	</td>
-          	<td width="30%" align="center">
-        		<label> Escalation ${radioId}</label>
-          	</td>
-        </tr>
-        <tr>
-        	<td style="vertical-align: middle">
-        		<table>
-          			<tr>
-          				<f:entry field="meteredValue" name="meteredValue">
-          					<f:enum>${it}</f:enum>
-          				</f:entry>
-          			</tr>
-          		</table>
-        	</td>
-        	<td style="vertical-align: middle">
-        		<table>
-        			<tr>
-        				<f:entry field="operator" name="operator">
-        					<f:enum>
-        						<j:if test="${!it.text.equals('not be equal to')}">
-   									${it}
-								</j:if>	
-        					</f:enum>
-          				</f:entry>
-        			</tr>
-        		</table>
-        	</td>
-        	<td style="vertical-align: middle">
-        	    <f:number field="tolerance" name="tolerance" default="0" min="0"/>
-        	</td>
-        	<td style="vertical-align: middle">
-        		<table>
-        			<tr>
-        				<f:entry field="escalationLevel" name="escalationLevel">
-          	  				<f:enum>${it}</f:enum>
-          				</f:entry>
-        			</tr>
-        		</table>
-        	</td>	
-        </tr>
-        <tr>
-          <td colspan="4">
-        	<table>
-          		<tr>
-          			<td>
-          				<j:set var="radioId" value="${h.generateId()}"/>
-            			<f:radioBlock name="${radioId}.previousResultsBlock" field="previousResultsBlock" value="true" title="Compare with number of previous builds" checked="${instance.getPreviousResultsBlock().isChoicePreviousResults()}">
-						<f:entry>
-            					<table cellspacing="5">
-            						<tr>
-            							<td>
-            								<label>Last </label>
-            							</td>
-            							<td width="40px">
-											<f:entry field="previousResultsString">
-												<f:textbox />
-											</f:entry>
-            							</td>
-            							<td>
-            								<label> builds</label>
-            							</td>
-            						</tr>
-            					</table>
-							</f:entry>	
-           				</f:radioBlock>
-            		</td>
-            	</tr>  	
-            </table>
-          </td>
-        </tr>
-        <tr>
-          <td colspan="4">
-          	<table>
-          		<tr>
-          			<td>
-            			<f:radioBlock name="${radioId}.previousResultsBlock" field="previousResultsBlock" value="false" title="Compare with Builds within a timeframe" checked="${instance.getPreviousResultsBlock().isChoiceTimeframe()}">
-						<f:entry>
-            				<table cellspacing="5">
-            					<tr>
-            						<td>
-            							<label>Builds between </label>
-            						</td>
-            						<td width="70px">
-										<f:entry field="timeframeStartString">
-											<f:textbox maxlength="16"/>
-										</f:entry>	
-            						</td>
-            						<td>
-            							<label> and </label>
-            						</td>
-            						<td width="70px">
-										<f:entry field="timeframeEndString">
-											<f:textbox maxlength="16"/>
-										</f:entry>	
-            						</td>
-            					</tr>
-            				</table>
-						</f:entry>	
-            			</f:radioBlock>
-            		</td>
-            	</tr>  	
-            </table>
-          </td>
-        </tr>
-        <tr>
-          <td colspan="4">
-        	<table>
-          		<tr>
-          			<td>
-            			<f:radioBlock name="${radioId}.previousResultsBlock" field="previousResultsBlock" value="BASELINE" title="Compare with baseline build" checked="${instance.getPreviousResultsBlock().isChoiceBaselineBuild()}">
-           				</f:radioBlock>
-            		</td>
-            	</tr>
-            </table>
-          </td>
-        </tr>
-      </table>
-     </f:entry>
-		
-	</f:block>
-
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:p="/lib/performance">
+  <f:block>
+    <f:entry>
+      <p:blockWrapper tableStyle="width: 500px; cellspacing:0; border:0px;">
+        <f:block>
+          <f:entry title="Related Report" field="relatedPerfReport">
+            <f:textbox name="relatedPerfReport"/>
+          </f:entry>
+        </f:block>
+        <f:block>
+          <f:optionalBlock name="testCaseBlock" title="Specify a test case" checked="${instance.getTestCaseBlock() != null}">
+            <f:entry field="testCase">
+              <f:textbox name="testCase"/>
+            </f:entry>
+          </f:optionalBlock>
+        </f:block>
+        <f:block>
+          <table>
+            <tr>
+              <td width="25%" align="center">
+                <label> Metric </label>
+              </td>
+              <td width="30%" align="center">
+                <label> Operator </label>
+              </td>
+              <td width="15%" align="center">
+                <label> Tolerance-%</label>
+              </td>
+              <td width="30%" align="center">
+                <label> Escalation ${radioId}</label>
+              </td>
+            </tr>
+            <tr>
+              <td style="vertical-align: middle">
+                <table>
+                  <tr>
+                    <f:entry field="meteredValue" name="meteredValue">
+                      <f:enum>${it}</f:enum>
+                    </f:entry>
+                  </tr>
+                </table>
+              </td>
+              <td style="vertical-align: middle">
+                <table>
+                  <tr>
+                    <f:entry field="operator" name="operator">
+                      <f:enum>
+                        <j:if test="${!it.text.equals('not be equal to')}">${it}</j:if>
+                      </f:enum>
+                    </f:entry>
+                  </tr>
+                </table>
+              </td>
+              <td style="vertical-align: middle">
+                <table>
+                  <tr>
+                    <f:entry field="tolerance" name="tolerance">
+                      <f:number field="tolerance" name="tolerance" default="0" min="0"/>
+                    </f:entry>
+                  </tr>
+                </table>
+              </td>
+              <td style="vertical-align: middle">
+                <table>
+                  <tr>
+                    <f:entry field="escalationLevel" name="escalationLevel">
+                      <f:enum>${it}</f:enum>
+                    </f:entry>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </f:block>
+        <j:set var="radioId" value="${h.generateId()}"/>
+        <f:block>
+          <f:radioBlock name="${radioId}.previousResultsBlock" field="previousResultsBlock" value="true"
+              title="Compare with number of previous builds" checked="${instance.getPreviousResultsBlock().isChoicePreviousResults()}">
+            <f:entry title="Number of previous builds" field="previousResultsString">
+              <f:number min="1" />
+            </f:entry>
+          </f:radioBlock>
+        </f:block>
+        <f:block>
+          <f:radioBlock name="${radioId}.previousResultsBlock" field="previousResultsBlock" value="false"
+              title="Compare with Builds within a timeframe" checked="${instance.getPreviousResultsBlock().isChoiceTimeframe()}">
+            <f:entry>
+              <f:entry title="Min date/time" field="timeframeStartString">
+                <f:textbox maxlength="16"/>
+              </f:entry>
+              <f:entry title="Max date/time" field="timeframeEndString">
+                <f:textbox maxlength="16"/>
+              </f:entry>
+            </f:entry>
+          </f:radioBlock>
+        </f:block>
+        <f:block>
+          <f:radioBlock name="${radioId}.previousResultsBlock" field="previousResultsBlock" value="BASELINE"
+              title="Compare with baseline build" checked="${instance.getPreviousResultsBlock().isChoiceBaselineBuild()}">
+          </f:radioBlock>
+        </f:block>
+      </p:blockWrapper>
+    </f:entry>
+  </f:block>
 </j:jelly>

--- a/src/main/resources/lib/performance/blockWrapper.jelly
+++ b/src/main/resources/lib/performance/blockWrapper.jelly
@@ -1,0 +1,35 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <st:documentation>
+    This adds a wrapper allowing adding an ID to a field or group of fields that can be targeted by JavaScript
+    The wrapper will be a `table` tag on Jenkins Core less than 2.264, and a `div` tag after that.
+
+    <st:attribute name="id">
+      ID to add to the wrapper
+    </st:attribute>
+    <st:attribute name="style">
+      Inline style to pass to the wrapper tag
+    </st:attribute>
+    <st:attribute name="tableStyle">
+      Inline style to pass to the wrapper tag (table only)
+    </st:attribute>
+    <st:attribute name="divStyle">
+      Inline style to pass to the wrapper tag (div only)
+    </st:attribute>
+
+  </st:documentation>
+
+  <j:choose>
+    <j:when test="${divBasedFormLayout}">
+      <div id="${attrs.id}" style="${attrs.style};${attrs.divStyle}">
+        <d:invokeBody/>
+      </div>
+    </j:when>
+    <j:otherwise>
+      <table id="${attrs.id}" style="${attrs.style};${attrs.tableStyle}">
+        <d:invokeBody/>
+      </table>
+    </j:otherwise>
+  </j:choose>
+
+</j:jelly>


### PR DESCRIPTION
See [JENKINS-64990](https://issues.jenkins.io/browse/JENKINS-64990).

The Performance plugin is currently broken when running Jenkins 2.264+ (or LTS 2.277.x / 2.289.x). Several blocks of the `PerformancePublisher` form use tables, in ways which conflict with the recent(-ish) [tables-to-divs](https://www.jenkins.io/doc/developer/views/table-to-div-migration/) conversion of the Jenkins UI.

This PR tries to fix that. It changes three jelly files:
- `.../PerformancePublisher/config.jelly`
- `.../constraints/AbsoluteConstraint/config.jelly`
- `.../constraints/RelativeConstraint/config.jelly`

All changes are made in the spirit of keeping compatibility with both layouts, tables-based (up to 2.2.63.x) and divs-based (2.264+). One trick I've used is a `blockWrapper` Jelly tag, inspired by the migration doc and by [the Artifactory plugin](https://github.com/jfrog/jenkins-artifactory-plugin/blob/master/src/main/resources/lib/jfrog/blockWrapper.jelly): it outputs either a `<table>` or a `<div>`, depending on the runtime Jenkins version.

I've not limited myself to exactly preserving the original forms layout on pre-2.263 though. I've tried to simplify the Jelly/HTML code a bit where I was considering it would still produce an okay form on older Jenkins, and it was making things easier or better on 2.264+.

In particular, I've used a few more [radioBlock](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/lib/form/radioBlock.jelly) than in the original layout (in `inline` mode, to avoid impact on the descriptor classes). But I did not go as far as making `radioBlocks` for the main *Standard mode* / *Expert mode* choice: I've tried, I've had good results with div-based layout, but not really with the table-based one, so I've rolled that back. Could be something to consider if you ever decide to depend on a 2.264+ baseline (and when that happen, there would be more possible cleanups, like getting rid of the `blockWrapper` tag).

I've also re-indented the constraints config jelly files, because the space/tabs mix was in my way. For reviewing this PR, you really want to ignore whitespace changes anyway, otherwise it will look like a 100% code change on the three files.

As for testing, there is no new unit test, obviously. I've done some manual tests (click things and fill some inputs / save job config / reopen job config) on:
- an `hpi:run` of this PR branch
- an `hpi:run` of this PR cherry-picked on top of my [deps-jenkins-2.277](/thomasgl-orange/performance-plugin/tree/deps-jenkins-2.277) branch (see [tables-to-divs-2.277](/thomasgl-orange/performance-plugin/tree/tables-to-divs-2.277))

More manual tests would obviously be welcome.

Regarding this `deps-jenkins-2.277` branch, I actually have three of them:
- [deps-jenkins-2.235](/thomasgl-orange/performance-plugin/tree/deps-jenkins-2.235)
- [deps-jenkins-2.263](/thomasgl-orange/performance-plugin/tree/deps-jenkins-2.263)
- [deps-jenkins-2.277](/thomasgl-orange/performance-plugin/tree/deps-jenkins-2.277)

I can PR any of them if you're interested in moving your `pom.xml` a bit forward (more recent Jenkins baseline, use the [bom](/jenkinsci/bom) to cleanup dependencies). You might want to have a look on [your plugin stats](https://stats.jenkins.io/pluginversions/performance.html) and [the guidelines](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) to decide what could be a suitable new Jenkins baseline.


**EDIT:** Forgot to attach a few screenshots I made:

<details>
<summary>Original form on Jenkins 1.642.3 (hpi:run on master)</summary>

![jenkins-1_642-original](https://user-images.githubusercontent.com/6212720/124425504-eef06000-dd68-11eb-92e5-e124d2b37c7b.png)
</details>

<details>
<summary>This PR on Jenkins 1.642.3</summary>

![jenkins-1_642-with-this-PR](https://user-images.githubusercontent.com/6212720/124425521-f3b51400-dd68-11eb-9d3c-b561e1376629.png)
</details>

<details>
<summary>This PR on Jenkins 2.277.x</summary>

![jenkins-2_277-with-this-PR](https://user-images.githubusercontent.com/6212720/124425530-f7e13180-dd68-11eb-923b-8f6fc6b6e770.png)
</details>


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] ~Link to relevant pull requests, esp. upstream and downstream changes~
- [ ] ~Ensure you have provided tests - that demonstrates feature works or fixes the issue~
