### PR TITLE
Fix UnsupportedOperationException: Refusing to marshal java.text.SimpleDateFormat for security reasons

### DIFF
--- a/src/main/java/hudson/plugins/performance/parsers/AbstractParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/AbstractParser.java
@@ -51,7 +51,7 @@ public abstract class AbstractParser extends PerformanceReportParser {
     private static final Cache<String, PerformanceReport> CACHE = CacheBuilder.newBuilder().maximumSize(1000).softValues().build();
 
     protected boolean isNumberDateFormat = false;
-    protected SimpleDateFormat format;
+    protected transient SimpleDateFormat format;
 
     protected static final String[] DATE_FORMATS = new String[]{
             "yyyy/MM/dd HH:mm:ss.SSS", "yyyy-MM-dd HH:mm:ss.SSS", "yyyy-MM-dd HH:mm:ss,SSS", "yyyy/mm/dd HH:mm:ss"

--- a/src/test/java/hudson/plugins/performance/PerformancePublisherTest.java
+++ b/src/test/java/hudson/plugins/performance/PerformancePublisherTest.java
@@ -93,6 +93,25 @@ public class PerformancePublisherTest {
     }
 
     @Test
+    public void testBuildWithFormattedTimeStamp() throws Exception {
+        final FreeStyleProject p = jenkinsRule.createFreeStyleProject();
+        p.getBuildersList().add(new TestBuilder() {
+            @Override
+            public boolean perform(AbstractBuild<?, ?> build,
+                    Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
+                build.getWorkspace().child("test.csv").copyFrom(
+                        getClass().getResource("/JMeterPublisher_formatted_timeStamp.csv"));
+                return true;
+            }
+        });
+        p.getPublishersList().add(new PerformancePublisher("test.csv"));
+
+        FreeStyleBuild b = jenkinsRule.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0).get());
+        b.save();
+    }
+
+    @Test
     public void testStandardResultsXML() throws Exception {
         FreeStyleProject p = jenkinsRule.createFreeStyleProject();
         p.getBuildersList().add(new TestBuilder() {

--- a/src/test/resources/JMeterPublisher_formatted_timeStamp.csv
+++ b/src/test/resources/JMeterPublisher_formatted_timeStamp.csv
@@ -1,0 +1,4 @@
+timeStamp,elapsed,label,responseCode,responseMessage,threadName,dataType,success,bytes
+2014-02-24 07:42:21.256,1300,GET /ordermgmt/login - Login Page,501,FAIL,Thread Group 1-1,text,false,3478
+2014-02-24 07:42:21.257,2000,GET /ordermgmt/pre-logout,200,OK,Thread Group 1-1,text,true,19714
+2014-02-24 07:42:21.258,1000,GET /ordermgmt/pre-logout,200,OK,Thread Group 1-1,text,true,19714


### PR DESCRIPTION
Fixes the `UnsupportedOperationException: Refusing to marshal java.text.SimpleDateFormat for security reasons` by re-applying patch from #170 