### PR TITLE
Clean up Mockito dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,14 +101,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>5.2.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy</artifactId>
-            <version>1.14.8</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
It's best to use the Mockito version defined in the plugin parent POM, as we keep this up-to-date without putting this burden on plugin maintainers. In the most recent version `mockito-inline` has been removed, and `mockito-core` is now based on the inline mock maker, so this PR adapts accordingly. In addition, Byte Buddy is managed via the plugin parent POM, so no need to use an explicit version here.