### PR TITLE
Update parent POM, update dependencies, solve spotbug errors, test with Java 21 #105

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ node('linux-amd64') {
             sh 'pip install -r requirements.txt'
             
             def args = ['clean', 'install', '-Dset.changelist']
-            infra.runMaven(args, 11)
+            infra.runMaven(args, 21)
         }
     }
 

--- a/src/main/java/hudson/plugins/performance/PerformancePublisher.java
+++ b/src/main/java/hudson/plugins/performance/PerformancePublisher.java
@@ -880,9 +880,8 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
         File xmlDirectory = createArchiveDirectoryIfMissing(run);
 
         File xmlfile = new File(xmlDirectory, "dashBoard_results.xml");
-
-        try (FileWriter fw = new FileWriter(xmlfile);
-                BufferedWriter bw = new BufferedWriter(fw)) {            
+        try (OutputStreamWriter fw = new OutputStreamWriter(new FileOutputStream(xmlfile), StandardCharsets.UTF_8);
+             BufferedWriter bw = new BufferedWriter(fw)) {
 
             String buildNo = "\t<buildNum>" + (compareBuildPrevious ? "previous" : nthBuildNumber) + "</buildNum>\n";
 

--- a/src/main/java/hudson/plugins/performance/PerformancePublisher.java
+++ b/src/main/java/hudson/plugins/performance/PerformancePublisher.java
@@ -1,10 +1,7 @@
 package hudson.plugins.performance;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintStream;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -646,9 +643,8 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
         String[] arr = glob.split("/");
 
         File xmlfile = new File(xmlDirectory, "/dashBoard_" + arr[arr.length - 1].split("\\.")[0] + ".xml");
-
-        try (FileWriter fw = new FileWriter(xmlfile);
-                BufferedWriter bw = new BufferedWriter(fw)) {            
+        try (OutputStreamWriter fw = new OutputStreamWriter(new FileOutputStream(xmlfile), StandardCharsets.UTF_8);
+             BufferedWriter bw = new BufferedWriter(fw)) {
             String xml = "<?xml version=\"1.0\"?>\n";
             xml += "<results>\n";
             xml += "<absoluteDefinition>\n";

--- a/src/main/java/hudson/plugins/performance/PerformancePublisher.java
+++ b/src/main/java/hudson/plugins/performance/PerformancePublisher.java
@@ -452,8 +452,14 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
 
             List<FilePath> files = locatePerformanceReports(workspace, glob);
             if (files.isEmpty()) {
-                if (run.getResult().isWorseThan(Result.UNSTABLE)) {
-                    return Collections.emptyList();
+                Result result = run.getResult();
+                if (result != null) {
+                    if (result.isWorseThan(Result.UNSTABLE)) {
+                        return Collections.emptyList();
+                    }
+                } else {
+                    // Handle the situation when result is null
+                    logger.println("Result is null");
                 }
 
                 if (failBuildIfNoResultFile) {

--- a/src/main/java/hudson/plugins/performance/PerformancePublisher.java
+++ b/src/main/java/hudson/plugins/performance/PerformancePublisher.java
@@ -603,7 +603,7 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
     private void writeStandardResultsToXML(Run<?, ?> run, Collection<PerformanceReport> parsedReports) throws IOException {
         File xmlDirectory = createArchiveDirectoryIfMissing(run);
         File xmlfile = new File(xmlDirectory, "standardResults.xml");
-        try (FileWriter fw = new FileWriter(xmlfile);
+        try (OutputStreamWriter fw = new OutputStreamWriter(new FileOutputStream(xmlfile), StandardCharsets.UTF_8);
                 BufferedWriter bw = new BufferedWriter(fw)){
             
             String xml = new StringBuilder("<?xml version=\"1.0\"?>\n")

--- a/src/main/java/hudson/plugins/performance/PerformancePublisher.java
+++ b/src/main/java/hudson/plugins/performance/PerformancePublisher.java
@@ -1052,7 +1052,13 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
         if (junitOutput != null && !junitOutput.isEmpty()) {
             listener.getLogger().println("Performance: Generating JUnit output: "+junitOutput);
             FilePath output = new FilePath(workspace, junitOutput);
-            output.getParent().mkdirs();
+            FilePath parent = output.getParent();
+            if (parent != null) {
+                parent.mkdirs();
+            } else {
+                // Handle the situation when parent is null
+                listener.getLogger().println("Failed to create parent dirs because the path is null.");
+            }
             try {
                 String junitReport = cr.getJunitReport();
                 if (junitReport != null) {

--- a/src/main/java/hudson/plugins/performance/PerformancePublisher.java
+++ b/src/main/java/hudson/plugins/performance/PerformancePublisher.java
@@ -1054,7 +1054,12 @@ public class PerformancePublisher extends Recorder implements SimpleBuildStep {
             FilePath output = new FilePath(workspace, junitOutput);
             output.getParent().mkdirs();
             try {
-                output.write(cr.getJunitReport(), null);
+                String junitReport = cr.getJunitReport();
+                if (junitReport != null) {
+                    output.write(junitReport, null);
+                } else {
+                    listener.getLogger().println("Failed to write JUnit file because junitreport is null.");
+                }
             }
             catch (IOException ex) {
                 listener.getLogger().println("Failed to write JUnit file: "+ex.getMessage());

--- a/src/main/java/hudson/plugins/performance/PerformanceReportMap.java
+++ b/src/main/java/hudson/plugins/performance/PerformanceReportMap.java
@@ -585,6 +585,10 @@ public class PerformanceReportMap implements ModelObject {
         String filename = getTrendReportFilename(request);
         PerformanceReport report = performanceReportMap.get(filename);
         Run<?, ?> build = getBuild();
+        if (build == null) {
+            // Handle the situation when build is null
+            return null;
+        }
 
         TrendReportGraphs trendReport = new TrendReportGraphs(build.getParent(),
                 build, request, filename, report);

--- a/src/main/java/hudson/plugins/performance/PerformanceReportMap.java
+++ b/src/main/java/hudson/plugins/performance/PerformanceReportMap.java
@@ -443,15 +443,14 @@ public class PerformanceReportMap implements ModelObject {
         Map<Run<?, ?>, Map<String, PerformanceReport>> buildReports = getBuildReports(parameter, previousBuild);
         DataSetBuilder<NumberOnlyBuildLabel, String> dataSetBuilderSummarizer = new DataSetBuilder<NumberOnlyBuildLabel, String>();
         ReportValueSelector valueSelector = ReportValueSelector.get(getBuild().getParent());
-
-        for (Run<?, ?> currentBuild : buildReports.keySet()) {
-            NumberOnlyBuildLabel label = new NumberOnlyBuildLabel(currentBuild);
-            PerformanceReport report = buildReports.get(currentBuild).get(parameter);
+        for (Map.Entry<Run<?, ?>, Map<String, PerformanceReport>> entry : buildReports.entrySet()) {
+            NumberOnlyBuildLabel label = new NumberOnlyBuildLabel(entry.getKey());
+            PerformanceReport report = entry.getValue().get(parameter);
 
             // Now we should have the data necessary to generate the graphs!
-            for (Map.Entry<String, UriReport> entry : report.getUriReportMap().entrySet()) {
-                long methodValue = valueSelector.getValue(entry.getValue());
-                dataSetBuilderSummarizer.add(methodValue, label, entry.getKey());
+            for (Map.Entry<String, UriReport> secondEntry : report.getUriReportMap().entrySet()) {
+                long methodValue = valueSelector.getValue(secondEntry.getValue());
+                dataSetBuilderSummarizer.add(methodValue, label, secondEntry.getKey());
             }
         }
 

--- a/src/main/java/hudson/plugins/performance/PerformanceReportMap.java
+++ b/src/main/java/hudson/plugins/performance/PerformanceReportMap.java
@@ -244,9 +244,9 @@ public class PerformanceReportMap implements ModelObject {
         DataSetBuilder<String, NumberOnlyBuildLabel> dataSetBuilder = new DataSetBuilder<String, NumberOnlyBuildLabel>();
         ReportValueSelector valueSelector = ReportValueSelector.get(getBuild().getParent());
         String keyLabel = getKeyLabel(valueSelector.getGraphType());
-        for (Run<?, ?> currentBuild : buildReports.keySet()) {
-            NumberOnlyBuildLabel label = new NumberOnlyBuildLabel(currentBuild);
-            PerformanceReport report = buildReports.get(currentBuild).get(parameter);
+        for (Map.Entry<Run<?, ?>, Map<String, PerformanceReport>> entry : buildReports.entrySet()) {
+            NumberOnlyBuildLabel label = new NumberOnlyBuildLabel(entry.getKey());
+            PerformanceReport report = entry.getValue().get(parameter);
             dataSetBuilder.add(valueSelector.getValue(report),
                     keyLabel, label);
         }
@@ -511,11 +511,15 @@ public class PerformanceReportMap implements ModelObject {
                             return false;
                         }
                     });
-                    try {
-                        collector.addAll(p.parse(build, Arrays.asList(listFiles), listener));
-                    } catch (IOException ex) {
-                        listener.getLogger().println("Unable to process directory '" + dir + "'.");
-                        ex.printStackTrace(listener.getLogger());
+                    if (listener != null && listener.getLogger() != null) {
+                        try {
+                            collector.addAll(p.parse(build, Arrays.asList(listFiles), listener));
+                        } catch (IOException ex) {
+                            listener.getLogger().println("Unable to process directory '" + dir + "'.");
+                            ex.printStackTrace(listener.getLogger());
+                        }
+                    } else {
+                        // Handle the situation when listener or its logger is null
                     }
                 }
             }

--- a/src/main/java/hudson/plugins/performance/PerformanceReportMap.java
+++ b/src/main/java/hudson/plugins/performance/PerformanceReportMap.java
@@ -443,16 +443,16 @@ public class PerformanceReportMap implements ModelObject {
         Map<Run<?, ?>, Map<String, PerformanceReport>> buildReports = getBuildReports(parameter, previousBuild);
         DataSetBuilder<NumberOnlyBuildLabel, String> dataSetBuilderSummarizer = new DataSetBuilder<NumberOnlyBuildLabel, String>();
         ReportValueSelector valueSelector = ReportValueSelector.get(getBuild().getParent());
+
         for (Run<?, ?> currentBuild : buildReports.keySet()) {
             NumberOnlyBuildLabel label = new NumberOnlyBuildLabel(currentBuild);
             PerformanceReport report = buildReports.get(currentBuild).get(parameter);
 
             // Now we should have the data necessary to generate the graphs!
-            for (String key : report.getUriReportMap().keySet()) {
-                long methodValue = valueSelector.getValue(report.getUriReportMap().get(key));
-                dataSetBuilderSummarizer.add(methodValue, label, key);
+            for (Map.Entry<String, UriReport> entry : report.getUriReportMap().entrySet()) {
+                long methodValue = valueSelector.getValue(entry.getValue());
+                dataSetBuilderSummarizer.add(methodValue, label, entry.getKey());
             }
-
         }
 
         new Graph(-1, 400, 200) {

--- a/src/main/java/hudson/plugins/performance/actions/PerformanceBuildAction.java
+++ b/src/main/java/hudson/plugins/performance/actions/PerformanceBuildAction.java
@@ -76,11 +76,13 @@ public class PerformanceBuildAction implements Action, StaplerProxy {
 
     public synchronized PerformanceReportMap getPerformanceReportMap(boolean isInitNextLevel) {
         PerformanceReportMap reportMap = null;
-        WeakReference<PerformanceReportMap> wr = this.performanceReportMap;
-        if (wr != null) {
-            reportMap = wr.get();
-            if (reportMap != null) {
-                return reportMap;
+        synchronized(this) {
+            WeakReference<PerformanceReportMap> wr = this.performanceReportMap;
+            if (wr != null) {
+                reportMap = wr.get();
+                if (reportMap != null) {
+                    return reportMap;
+                }
             }
         }
         try {

--- a/src/main/java/hudson/plugins/performance/actions/PerformanceBuildAction.java
+++ b/src/main/java/hudson/plugins/performance/actions/PerformanceBuildAction.java
@@ -94,8 +94,9 @@ public class PerformanceBuildAction implements Action, StaplerProxy {
         return reportMap;
     }
 
-
-    public void setPerformanceReportMap(WeakReference<PerformanceReportMap> performanceReportMap) {
-        this.performanceReportMap = performanceReportMap;
+    public synchronized void setPerformanceReportMap(WeakReference<PerformanceReportMap> performanceReportMap) {
+        synchronized(this) {
+            this.performanceReportMap = performanceReportMap;
+        }
     }
 }

--- a/src/main/java/hudson/plugins/performance/actions/PerformanceBuildAction.java
+++ b/src/main/java/hudson/plugins/performance/actions/PerformanceBuildAction.java
@@ -70,7 +70,7 @@ public class PerformanceBuildAction implements Action, StaplerProxy {
         return hudsonConsoleWriter;
     }
 
-    public PerformanceReportMap getPerformanceReportMap() {
+    public synchronized PerformanceReportMap getPerformanceReportMap() {
         return getPerformanceReportMap(true);
     }
 

--- a/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
+++ b/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
@@ -52,11 +52,8 @@ import java.io.File;
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.GregorianCalendar;
+import java.util.*;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -783,7 +780,7 @@ public class PerformanceProjectAction implements Action {
             return performanceReportList;
         }
 
-        for (File entry : file.listFiles()) {
+        for (File entry : Objects.requireNonNull(file.listFiles())) {
             if (entry.isDirectory()) {
                 for (File e : entry.listFiles()) {
                     if (!e.getName().endsWith(".serialized") && !e.getName().endsWith(".serialized-v2")) {

--- a/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
+++ b/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
@@ -47,6 +47,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+
 import java.awt.*;
 import java.io.File;
 import java.io.IOException;
@@ -240,7 +241,7 @@ public class PerformanceProjectAction implements Action {
     }
 
     public static JFreeChart doCreateSummarizerChart(CategoryDataset dataset,
-            String yAxis, String chartTitle) {
+                                                     String yAxis, String chartTitle) {
 
         final JFreeChart chart = ChartFactory.createBarChart(chartTitle, // chart
                 // title
@@ -546,7 +547,7 @@ public class PerformanceProjectAction implements Action {
             protected JFreeChart createGraph() {
                 return createRespondingTimeChart(dataSetBuilderAverage.build(), limit);
             }
-        }.doPng(request, response);      
+        }.doPng(request, response);
     }
 
     public void doThroughputGraph(final StaplerRequest request, final StaplerResponse response) throws IOException {
@@ -784,11 +785,15 @@ public class PerformanceProjectAction implements Action {
 
             for (File entry : Objects.requireNonNull(file.listFiles())) {
                 if (entry.isDirectory()) {
-                    for (File e : Objects.requireNonNull(entry.listFiles())) {
-                        if (!e.getName().endsWith(".serialized") && !e.getName().endsWith(".serialized-v2")) {
-                            this.performanceReportList.add(e.getName());
+                    File[] entryFiles = entry.listFiles();
+                    if (entryFiles != null) {
+                        for (File e : Objects.requireNonNull(entryFiles)) {
+                            if (!e.getName().endsWith(".serialized") && !e.getName().endsWith(".serialized-v2")) {
+                                this.performanceReportList.add(e.getName());
+                            }
                         }
                     }
+
                 } else {
                     if (!entry.getName().endsWith(".serialized") && !entry.getName().endsWith(".serialized-v2")) {
                         this.performanceReportList.add(entry.getName());
@@ -823,7 +828,7 @@ public class PerformanceProjectAction implements Action {
      * @return the dynamic result of the analysis (detail page).
      */
     public Object getDynamic(final String link, final StaplerRequest request,
-            final StaplerResponse response) {
+                             final StaplerResponse response) {
         if (CONFIGURE_LINK.equals(link)) {
             return createUserConfiguration(request);
         } else if (TRENDREPORT_LINK.equals(link)) {
@@ -876,7 +881,7 @@ public class PerformanceProjectAction implements Action {
     }
 
     private DataSetBuilder<String, NumberOnlyBuildLabel> getTrendReportData(final StaplerRequest request,
-            String performanceReportNameFile) {
+                                                                            String performanceReportNameFile) {
 
         DataSetBuilder<String, NumberOnlyBuildLabel> dataSet = new DataSetBuilder<>();
         List<? extends Run<?, ?>> builds = getJob().getBuilds();

--- a/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
+++ b/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
@@ -782,7 +782,7 @@ public class PerformanceProjectAction implements Action {
 
         for (File entry : Objects.requireNonNull(file.listFiles())) {
             if (entry.isDirectory()) {
-                for (File e : entry.listFiles()) {
+                for (File e : Objects.requireNonNull(entry.listFiles())) {
                     if (!e.getName().endsWith(".serialized") && !e.getName().endsWith(".serialized-v2")) {
                         this.performanceReportList.add(e.getName());
                     }

--- a/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
+++ b/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
@@ -782,7 +782,7 @@ public class PerformanceProjectAction implements Action {
         }
         File[] files = file.listFiles();
 
-        if (file.listFiles() != null) {
+        if (files != null) {
             for (File entry : Objects.requireNonNull(file.listFiles())) {
                 if (entry.isDirectory()) {
                     File[] entryFiles = entry.listFiles();

--- a/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
+++ b/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
@@ -781,8 +781,8 @@ public class PerformanceProjectAction implements Action {
             return performanceReportList;
         }
         File[] files = file.listFiles();
-        if (files != null) {
 
+        if (file.listFiles() != null) {
             for (File entry : Objects.requireNonNull(file.listFiles())) {
                 if (entry.isDirectory()) {
                     File[] entryFiles = entry.listFiles();
@@ -801,6 +801,7 @@ public class PerformanceProjectAction implements Action {
                 }
 
             }
+
         } else {
             // Handle the situation when files is null
             return performanceReportList;

--- a/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
+++ b/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
@@ -779,20 +779,26 @@ public class PerformanceProjectAction implements Action {
         if (!file.isDirectory()) {
             return performanceReportList;
         }
+        File[] files = file.listFiles();
+        if (files != null) {
 
-        for (File entry : Objects.requireNonNull(file.listFiles())) {
-            if (entry.isDirectory()) {
-                for (File e : Objects.requireNonNull(entry.listFiles())) {
-                    if (!e.getName().endsWith(".serialized") && !e.getName().endsWith(".serialized-v2")) {
-                        this.performanceReportList.add(e.getName());
+            for (File entry : Objects.requireNonNull(file.listFiles())) {
+                if (entry.isDirectory()) {
+                    for (File e : Objects.requireNonNull(entry.listFiles())) {
+                        if (!e.getName().endsWith(".serialized") && !e.getName().endsWith(".serialized-v2")) {
+                            this.performanceReportList.add(e.getName());
+                        }
+                    }
+                } else {
+                    if (!entry.getName().endsWith(".serialized") && !entry.getName().endsWith(".serialized-v2")) {
+                        this.performanceReportList.add(entry.getName());
                     }
                 }
-            } else {
-                if (!entry.getName().endsWith(".serialized") && !entry.getName().endsWith(".serialized-v2")) {
-                    this.performanceReportList.add(entry.getName());
-                }
-            }
 
+            }
+        } else {
+            // Handle the situation when files is null
+            return performanceReportList;
         }
 
         Collections.sort(performanceReportList);

--- a/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
+++ b/src/main/java/hudson/plugins/performance/actions/PerformanceProjectAction.java
@@ -783,7 +783,7 @@ public class PerformanceProjectAction implements Action {
         File[] files = file.listFiles();
 
         if (files != null) {
-            for (File entry : Objects.requireNonNull(file.listFiles())) {
+            for (File entry : files) {
                 if (entry.isDirectory()) {
                     File[] entryFiles = entry.listFiles();
                     if (entryFiles != null) {

--- a/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
+++ b/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
@@ -49,7 +49,7 @@ public class PerformanceTestBuild extends Builder implements SimpleBuildStep {
 
     protected final static String[] CREATE_LOCAL_PYTHON_COMMAND_WITH_SYSTEM_PACKAGES_OPTION =
             new String[]{VIRTUALENV_COMMAND, "--clear", "--system-site-packages", "taurus-venv"};
-    protected final static String[] CREATE_LOCAL_PYTHON_COMMAND = new String[]{VIRTUALENV_COMMAND, "--clear", "taurus-venv"};
+    final static String[] CREATE_LOCAL_PYTHON_COMMAND = new String[]{VIRTUALENV_COMMAND, "--clear", "taurus-venv"};
 
     protected final static String DEFAULT_CONFIG_FILE = "jenkins-report.yml";
 

--- a/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
+++ b/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
@@ -44,8 +44,8 @@ public class PerformanceTestBuild extends Builder implements SimpleBuildStep {
     protected final static String VIRTUALENV_PATH_UNIX = "/taurus-venv/bin/";
     protected final static String VIRTUALENV_PATH_WINDOWS = "\\taurus-venv\\Scripts\\";
 
-    protected final static String[] CHECK_BZT_COMMAND = new String[]{PERFORMANCE_TEST_COMMAND, HELP_OPTION};
-    protected final static String[] CHECK_VIRTUALENV_COMMAND = new String[]{VIRTUALENV_COMMAND, HELP_OPTION};
+    final static String[] CHECK_BZT_COMMAND = new String[]{PERFORMANCE_TEST_COMMAND, HELP_OPTION};
+    final static String[] CHECK_VIRTUALENV_COMMAND = new String[]{VIRTUALENV_COMMAND, HELP_OPTION};
 
     final static String[] CREATE_LOCAL_PYTHON_COMMAND_WITH_SYSTEM_PACKAGES_OPTION =
             new String[]{VIRTUALENV_COMMAND, "--clear", "--system-site-packages", "taurus-venv"};

--- a/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
+++ b/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
@@ -23,11 +23,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.PrintStream;
+
+import java.io.*;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -149,7 +146,6 @@ public class PerformanceTestBuild extends Builder implements SimpleBuildStep {
                     getBztJobResult(testExitCode) :
                     getJobResult(testExitCode)
             );
-
             if (generatePerformanceTrend && run.getResult().isBetterThan(Result.FAILURE)) {
                 generatePerformanceTrend(bztWorkingDirectory.getRemote(), run, workspace, launcher, listener);
             }
@@ -432,7 +428,10 @@ public class PerformanceTestBuild extends Builder implements SimpleBuildStep {
 
     protected String extractDefaultReportToWorkingDirectory(FilePath workingDirectory) throws IOException, InterruptedException {
         FilePath defaultConfig = workingDirectory.child(DEFAULT_CONFIG_FILE);
-        defaultConfig.copyFrom(getClass().getResourceAsStream(DEFAULT_CONFIG_FILE));
+        try (InputStream is = getClass().getResourceAsStream(DEFAULT_CONFIG_FILE)) {
+            assert is != null;
+            defaultConfig.copyFrom(is);
+        }
         return defaultConfig.getRemote();
     }
 

--- a/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
+++ b/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
@@ -47,7 +47,7 @@ public class PerformanceTestBuild extends Builder implements SimpleBuildStep {
     protected final static String[] CHECK_BZT_COMMAND = new String[]{PERFORMANCE_TEST_COMMAND, HELP_OPTION};
     protected final static String[] CHECK_VIRTUALENV_COMMAND = new String[]{VIRTUALENV_COMMAND, HELP_OPTION};
 
-    protected final static String[] CREATE_LOCAL_PYTHON_COMMAND_WITH_SYSTEM_PACKAGES_OPTION =
+    final static String[] CREATE_LOCAL_PYTHON_COMMAND_WITH_SYSTEM_PACKAGES_OPTION =
             new String[]{VIRTUALENV_COMMAND, "--clear", "--system-site-packages", "taurus-venv"};
     final static String[] CREATE_LOCAL_PYTHON_COMMAND = new String[]{VIRTUALENV_COMMAND, "--clear", "taurus-venv"};
 
@@ -143,7 +143,8 @@ public class PerformanceTestBuild extends Builder implements SimpleBuildStep {
                     getBztJobResult(testExitCode) :
                     getJobResult(testExitCode)
             );
-            if (generatePerformanceTrend && Result.FAILURE.isWorseThan(Objects.requireNonNull(run.getResult()))) {
+            Result result = run.getResult();
+            if (generatePerformanceTrend && result != null && Result.FAILURE.isWorseThan(result)) {
                 generatePerformanceTrend(bztWorkingDirectory.getRemote(), run, workspace, launcher, listener);
             }
 

--- a/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
+++ b/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
@@ -417,7 +417,7 @@ public class PerformanceTestBuild extends Builder implements SimpleBuildStep {
         try {
             return launcher.launch().cmds(commands).envs(envVars).stdout(logger).stderr(logger).pwd(workspace).start().join();
         } catch (IOException ex) {
-            logger.write(ex.getMessage().getBytes());
+            logger.write(ex.getMessage().getBytes(StandardCharsets.UTF_8));
             if (printDebugOutput) {
                 logger.write(Functions.printThrowable(ex).getBytes(StandardCharsets.UTF_8));
             }

--- a/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
+++ b/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
@@ -28,6 +28,7 @@ import java.io.*;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.InvalidPathException;
 import java.util.*;
 import java.util.logging.Logger;
@@ -418,7 +419,7 @@ public class PerformanceTestBuild extends Builder implements SimpleBuildStep {
         } catch (IOException ex) {
             logger.write(ex.getMessage().getBytes());
             if (printDebugOutput) {
-                logger.write(Functions.printThrowable(ex).getBytes());
+                logger.write(Functions.printThrowable(ex).getBytes(StandardCharsets.UTF_8));
             }
             return 1;
         }

--- a/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
+++ b/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java
@@ -29,10 +29,7 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.InvalidPathException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.logging.Logger;
 
 /**
@@ -146,7 +143,7 @@ public class PerformanceTestBuild extends Builder implements SimpleBuildStep {
                     getBztJobResult(testExitCode) :
                     getJobResult(testExitCode)
             );
-            if (generatePerformanceTrend && run.getResult().isBetterThan(Result.FAILURE)) {
+            if (generatePerformanceTrend && Result.FAILURE.isWorseThan(Objects.requireNonNull(run.getResult()))) {
                 generatePerformanceTrend(bztWorkingDirectory.getRemote(), run, workspace, launcher, listener);
             }
 

--- a/src/main/java/hudson/plugins/performance/constraints/AbstractConstraint.java
+++ b/src/main/java/hudson/plugins/performance/constraints/AbstractConstraint.java
@@ -239,11 +239,11 @@ public abstract class AbstractConstraint implements Describable<AbstractConstrai
         INFORMATION("Information", false), WARNING("Warning", false), ERROR("Error", false);
 
         private final String text;
-        private boolean isSelected;
+        private final boolean isSelected;
 
         private Escalation(final String text, boolean isSelected) {
             this.text = text;
-            this.setSelected(isSelected);
+            this.isSelected = isSelected;
         }
 
         @Override
@@ -255,9 +255,6 @@ public abstract class AbstractConstraint implements Describable<AbstractConstrai
             return isSelected;
         }
 
-        public void setSelected(boolean isSelected) {
-            this.isSelected = isSelected;
-        }
     }
 
     public enum Operator {

--- a/src/main/java/hudson/plugins/performance/constraints/AbstractConstraint.java
+++ b/src/main/java/hudson/plugins/performance/constraints/AbstractConstraint.java
@@ -217,11 +217,11 @@ public abstract class AbstractConstraint implements Describable<AbstractConstrai
         AVERAGE("Average", false), MEDIAN("Median", false), LINE90("90% Line", false), MAXIMUM("Maximum", false), MINIMUM("Minimum", false), ERRORPRC("Error %", false);
 
         private final String text;
-        private boolean isSelected;
+        private final boolean isSelected;
 
         private Metric(final String text, boolean isSelected) {
             this.text = text;
-            this.setSelected(isSelected);
+            this.isSelected = isSelected;
         }
 
         @Override
@@ -233,9 +233,6 @@ public abstract class AbstractConstraint implements Describable<AbstractConstrai
             return isSelected;
         }
 
-        public void setSelected(boolean isSelected) {
-            this.isSelected = isSelected;
-        }
     }
 
     public enum Escalation {

--- a/src/main/java/hudson/plugins/performance/constraints/AbstractConstraint.java
+++ b/src/main/java/hudson/plugins/performance/constraints/AbstractConstraint.java
@@ -267,11 +267,11 @@ public abstract class AbstractConstraint implements Describable<AbstractConstrai
         NOT_GREATER("not be greater than", false), NOT_LESS("not be less than", false), NOT_EQUAL("not be equal to", false);
 
         public final String text;
-        private boolean isSelected;
+        private final boolean isSelected;
 
         private Operator(final String text, boolean isSelected) {
             this.text = text;
-            this.setSelected(isSelected);
+            this.isSelected = isSelected;
         }
 
         @Override
@@ -283,9 +283,6 @@ public abstract class AbstractConstraint implements Describable<AbstractConstrai
             return isSelected;
         }
 
-        public void setSelected(boolean isSelected) {
-            this.isSelected = isSelected;
-        }
     }
 
     public void setSuccess(boolean success) {

--- a/src/main/java/hudson/plugins/performance/constraints/RelativeConstraint.java
+++ b/src/main/java/hudson/plugins/performance/constraints/RelativeConstraint.java
@@ -34,7 +34,7 @@ import hudson.util.RunList;
  *
  * @author Rene Kugel
  */
-public class RelativeConstraint extends AbstractConstraint {
+public class RelativeConstraint extends AbstractConstraint implements Cloneable {
     /**
      * Percentage value of the tolerance
      */

--- a/src/main/java/hudson/plugins/performance/constraints/RelativeConstraint.java
+++ b/src/main/java/hudson/plugins/performance/constraints/RelativeConstraint.java
@@ -34,7 +34,7 @@ import hudson.util.RunList;
  *
  * @author Rene Kugel
  */
-public class RelativeConstraint extends AbstractConstraint implements Cloneable {
+public class RelativeConstraint extends AbstractConstraint {
     /**
      * Percentage value of the tolerance
      */

--- a/src/main/java/hudson/plugins/performance/constraints/RelativeConstraint.java
+++ b/src/main/java/hudson/plugins/performance/constraints/RelativeConstraint.java
@@ -3,11 +3,7 @@ package hudson.plugins.performance.constraints;
 import java.io.PrintStream;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
-import java.util.ListIterator;
+import java.util.*;
 
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.AncestorInPath;
@@ -469,8 +465,8 @@ public class RelativeConstraint extends AbstractConstraint {
         int i = 1;
         int j = 0;
         while (j < getPreviousResults() && i < builds.size()) {
-            if (builds.get(i).getResult().equals(Result.SUCCESS) 
-                    || (builds.get(i).getResult().equals(Result.UNSTABLE) 
+            if (Objects.equals(builds.get(i).getResult(), Result.SUCCESS)
+                    || (Objects.equals(builds.get(i).getResult(), Result.UNSTABLE)
                     && !getSettings().isIgnoreUnstableBuilds())
                     || (Result.FAILURE.equals(builds.get(i).getResult()) && !getSettings().isIgnoreFailedBuilds())) {
                 result.add(builds.get(i));

--- a/src/main/java/hudson/plugins/performance/constraints/RelativeConstraint.java
+++ b/src/main/java/hudson/plugins/performance/constraints/RelativeConstraint.java
@@ -472,7 +472,7 @@ public class RelativeConstraint extends AbstractConstraint {
             if (builds.get(i).getResult().equals(Result.SUCCESS) 
                     || (builds.get(i).getResult().equals(Result.UNSTABLE) 
                     && !getSettings().isIgnoreUnstableBuilds())
-                    || (builds.get(i).getResult().equals(Result.FAILURE) && !getSettings().isIgnoreFailedBuilds())) {
+                    || (Result.FAILURE.equals(builds.get(i).getResult()) && !getSettings().isIgnoreFailedBuilds())) {
                 result.add(builds.get(i));
                 j++;
             }

--- a/src/main/java/hudson/plugins/performance/data/HttpSample.java
+++ b/src/main/java/hudson/plugins/performance/data/HttpSample.java
@@ -127,6 +127,14 @@ public class HttpSample implements Serializable, Comparable<HttpSample> {
         return (int) (getDuration() - o.getDuration());
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        HttpSample that = (HttpSample) obj;
+        return getDuration() == that.getDuration();
+    }
+
     public double getSizeInKb() {
         return sizeInKb;
     }

--- a/src/main/java/hudson/plugins/performance/data/HttpSample.java
+++ b/src/main/java/hudson/plugins/performance/data/HttpSample.java
@@ -4,6 +4,7 @@ import hudson.plugins.performance.reports.UriReport;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Objects;
 
 /**
  * Information about a particular HTTP request and how that went.
@@ -133,6 +134,11 @@ public class HttpSample implements Serializable, Comparable<HttpSample> {
         if (obj == null || getClass() != obj.getClass()) return false;
         HttpSample that = (HttpSample) obj;
         return getDuration() == that.getDuration();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getDuration());
     }
 
     public double getSizeInKb() {

--- a/src/main/java/hudson/plugins/performance/parsers/AbstractParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/AbstractParser.java
@@ -209,7 +209,7 @@ public abstract class AbstractParser extends PerformanceReportParser {
 
         try {
             return isNumberDateFormat ?
-                    new Date(Long.valueOf(timestamp)) :
+                    new Date(Long.parseLong(timestamp)) :
                     format.parse(timestamp);
         } catch (ParseException e) {
             throw new IllegalArgumentException("Cannot parse timestamp: " + timestamp +

--- a/src/main/java/hudson/plugins/performance/parsers/AbstractParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/AbstractParser.java
@@ -53,7 +53,7 @@ public abstract class AbstractParser extends PerformanceReportParser {
     protected boolean isNumberDateFormat = false;
     protected transient SimpleDateFormat format;
 
-    protected static final String[] DATE_FORMATS = new String[]{
+    static final String[] DATE_FORMATS = new String[]{
             "yyyy/MM/dd HH:mm:ss.SSS", "yyyy-MM-dd HH:mm:ss.SSS", "yyyy-MM-dd HH:mm:ss,SSS", "yyyy/mm/dd HH:mm:ss"
     };
 

--- a/src/main/java/hudson/plugins/performance/parsers/IagoParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/IagoParser.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -68,8 +69,8 @@ public class IagoParser extends AbstractParser {
         report.setShowTrendGraphs(showTrendGraphs);
         report.setReportFileName(reportFile.getName());
 
-        try (FileReader fr = new FileReader(reportFile);
-                BufferedReader reader = new BufferedReader(fr)){
+        try (FileReader fr = new FileReader(reportFile, StandardCharsets.UTF_8);
+             BufferedReader reader = new BufferedReader(fr)){
             String line = reader.readLine();
             while (line != null) {
                 final HttpSample sample = this.getSample(line, reportFile.getName());

--- a/src/main/java/hudson/plugins/performance/parsers/JMeterCsvParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/JMeterCsvParser.java
@@ -1,10 +1,7 @@
 package hudson.plugins.performance.parsers;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.Reader;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
@@ -65,8 +62,7 @@ public class JMeterCsvParser extends AbstractParser {
                 header = readCSVHeader(line);
             }
         }
-
-        try (Reader fileReader = new FileReader(reportFile)) {
+        try (Reader fileReader = new InputStreamReader(new FileInputStream(reportFile), StandardCharsets.UTF_8)) {
             parseCSV(fileReader, header, report);
         }
 

--- a/src/main/java/hudson/plugins/performance/parsers/JMeterCsvParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/JMeterCsvParser.java
@@ -131,14 +131,14 @@ public class JMeterCsvParser extends AbstractParser {
     private HttpSample getSample(CSVRecord record) {
         final HttpSample sample = new HttpSample();
         sample.setDate(parseTimestamp(record.get(timestampIdx)));
-        sample.setDuration(Long.valueOf(record.get(elapsedIdx)));
+        sample.setDuration(Long.parseLong(record.get(elapsedIdx)));
         sample.setHttpCode(record.get(responseCodeIdx));
-        sample.setSuccessful(Boolean.valueOf(record.get(successIdx)));
+        sample.setSuccessful(Boolean.parseBoolean(record.get(successIdx)));
         long bytes = Long.parseLong(record.get(bytesIdx));
         if (sentBytesIdx != -1) {
             bytes += Long.parseLong(record.get(sentBytesIdx));
         }
-        sample.setSizeInKb(Double.valueOf(bytes) / 1024d);
+        sample.setSizeInKb((double) bytes / 1024d);
         sample.setUri(record.get(urlIdx));
         return sample;
     }

--- a/src/main/java/hudson/plugins/performance/parsers/JMeterCsvParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/JMeterCsvParser.java
@@ -55,7 +55,7 @@ public class JMeterCsvParser extends AbstractParser {
         report.setReportFileName(reportFile.getName());
 
         String[] header = null;
-        try (FileReader fr = new FileReader(reportFile);
+        try (FileReader fr = new FileReader(reportFile, StandardCharsets.UTF_8);
                 BufferedReader reader = new BufferedReader(fr)) {
             String line = reader.readLine();
             if (line != null) {

--- a/src/main/java/hudson/plugins/performance/parsers/JMeterParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/JMeterParser.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 import javax.xml.parsers.SAXParserFactory;
@@ -68,7 +69,7 @@ public class JMeterParser extends AbstractParser {
      * @return <code>true</code> if the file content has been determined to be XML, otherwise <code>false</code>.
      */
     public static boolean isXmlFile(File file) throws IOException {
-        try (FileReader fr = new FileReader(file);
+        try (FileReader fr = new FileReader(file, StandardCharsets.UTF_8);
                 BufferedReader reader = new BufferedReader(fr)) {
             String line;
             boolean isXml = false;

--- a/src/main/java/hudson/plugins/performance/parsers/JMeterParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/JMeterParser.java
@@ -128,7 +128,7 @@ public class JMeterParser extends AbstractParser {
                 } else {
                     dateValue = attributes.getValue("timeStamp");
                 }
-                sample.setDate(new Date(Long.valueOf(dateValue)));
+                sample.setDate(new Date(Long.parseLong(dateValue)));
 
                 final String durationValue;
                 if (attributes.getValue("t") != null) {

--- a/src/main/java/hudson/plugins/performance/parsers/JMeterParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/JMeterParser.java
@@ -136,7 +136,7 @@ public class JMeterParser extends AbstractParser {
                 } else {
                     durationValue = attributes.getValue("time");
                 }
-                sample.setDuration(Long.valueOf(durationValue));
+                sample.setDuration(Long.parseLong(durationValue));
 
                 final String successfulValue;
                 if (attributes.getValue("s") != null) {
@@ -168,7 +168,7 @@ public class JMeterParser extends AbstractParser {
                 } else {
                     sizeInKbValue = "0";
                 }
-                sample.setSizeInKb(Double.valueOf(sizeInKbValue) / 1024d);
+                sample.setSizeInKb(Double.parseDouble(sizeInKbValue) / 1024d);
 
                 if (counter == 0) {
                     currentSample = sample;

--- a/src/main/java/hudson/plugins/performance/parsers/JmeterSummarizerParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/JmeterSummarizerParser.java
@@ -1,6 +1,7 @@
 package hudson.plugins.performance.parsers;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 import java.util.regex.Pattern;
 
@@ -49,8 +50,7 @@ public class JmeterSummarizerParser extends AbstractParser {
         report.setExcludeResponseTime(excludeResponseTime);
         report.setShowTrendGraphs(showTrendGraphs);
         report.setReportFileName(reportFile.getName());
-
-        try (Scanner fileScanner = new Scanner(reportFile)){
+        try (Scanner fileScanner = new Scanner(reportFile, StandardCharsets.UTF_8)){
             String line;
             String lastEqualsLine = null;
             while (fileScanner.hasNextLine()) {

--- a/src/main/java/hudson/plugins/performance/parsers/LocustParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/LocustParser.java
@@ -8,11 +8,8 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.Reader;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.List;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -96,9 +93,8 @@ public class LocustParser extends AbstractParser {
 
     List<CSVRecord> getCsvData(final File reportFile) {
         List<CSVRecord> records = null;
-        try (Reader reader = new BufferedReader(new FileReader(reportFile));
-                CSVParser csvParser = new CSVParser(reader,
-                        CSVFormat.Builder.create(CSVFormat.DEFAULT).setHeader().build())) {
+        try (Reader reader = new BufferedReader(new InputStreamReader(new FileInputStream(reportFile), StandardCharsets.UTF_8));
+             CSVParser csvParser = new CSVParser(reader, CSVFormat.Builder.create(CSVFormat.DEFAULT).setHeader().build())) {
             records = csvParser.getRecords();
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/hudson/plugins/performance/parsers/LocustParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/LocustParser.java
@@ -66,7 +66,7 @@ public class LocustParser extends AbstractParser {
             long max = Double.valueOf(record.get(ReportColumns.Max.getColumn())).longValue();
             long failures = Double.valueOf(record.get(ReportColumns.Failures.getColumn())).longValue();
             long success = Double.valueOf(record.get(ReportColumns.Requests.getColumn())).longValue();
-            long errors = Double.valueOf(failures / success).longValue();
+            long errors = (long) ((double) failures / success);
             long avgContentSize = Double.valueOf(record.get(ReportColumns.AvgContentSize.getColumn())).longValue();
 
             if (name.equals("Aggregated")) {

--- a/src/main/java/hudson/plugins/performance/parsers/ParserDetector.java
+++ b/src/main/java/hudson/plugins/performance/parsers/ParserDetector.java
@@ -1,11 +1,7 @@
 package hudson.plugins.performance.parsers;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -31,7 +27,7 @@ public class ParserDetector {
      * @return report file type.
      */
     public static String detect(String reportPath) throws IOException {
-        try (final BufferedReader reader = new BufferedReader(new FileReader(new File(reportPath)))) {
+        try (final BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(new File(reportPath)), StandardCharsets.UTF_8))) {
             String line = reader.readLine();
             if (line == null) {
                 throw new IllegalArgumentException("File " + reportPath + " is empty");

--- a/src/main/java/hudson/plugins/performance/parsers/TaurusParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/TaurusParser.java
@@ -93,20 +93,21 @@ public class TaurusParser extends AbstractParser {
     private TaurusFinalStats getTaurusFinalStats(Element group) {
         final TaurusFinalStats report = new TaurusFinalStats();
 
-        report.setBytes(Long.valueOf(getValueAttribute("bytes", group)));
-        report.setFail(Integer.valueOf(getValueAttribute("fail", group)));
-        report.setSucc(Integer.valueOf(getValueAttribute("succ", group)));
+        report.setBytes(Long.parseLong(getValueAttribute("bytes", group)));
+        report.setFail(Integer.parseInt(getValueAttribute("fail", group)));
+        report.setSucc(Integer.parseInt(getValueAttribute("succ", group)));
         if (group.getElementsByTagName("throughput").getLength() > 0) {
-            report.setThroughput(Long.valueOf(getValueAttribute("throughput", group)));
+            report.setThroughput(Long.parseLong(getValueAttribute("throughput", group)));
         }
-        report.setAverageResponseTime(Double.valueOf(getValueAttribute("avg_rt", group)) * 1000); // to ms
+        report.setAverageResponseTime(Double.parseDouble(getValueAttribute("avg_rt", group)) * 1000); // to ms
 
         NodeList perc = group.getElementsByTagName("perc");
         for (int i = 0; i < perc.getLength(); i++) {
             Node nNode = perc.item(i);
             String attributeParam = ((Element) nNode).getAttribute("param");
-            Double valueInMs = Double.valueOf(((Element) nNode).getAttribute("value")) * 1000;
-            
+            double valueInMs;
+            valueInMs = Double.parseDouble(((Element) nNode).getAttribute("value")) * 1000;
+
             if ("50.0".equals(attributeParam)) {
                 report.setPerc50(valueInMs); // to ms
             } else if ("90.0".equals(attributeParam)) {

--- a/src/main/java/hudson/plugins/performance/parsers/WrkSummarizerParser.java
+++ b/src/main/java/hudson/plugins/performance/parsers/WrkSummarizerParser.java
@@ -9,6 +9,7 @@ import hudson.plugins.performance.tools.SafeMaths;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Scanner;
 
@@ -85,7 +86,7 @@ public class WrkSummarizerParser extends AbstractParser {
 
         Scanner s = null;
         try {
-            s = new Scanner(reportFile);
+            s = new Scanner(reportFile, StandardCharsets.UTF_8);
             HttpSample sample = new HttpSample();
 
             while (s.hasNextLine()) {

--- a/src/main/java/hudson/plugins/performance/reports/ConstraintReport.java
+++ b/src/main/java/hudson/plugins/performance/reports/ConstraintReport.java
@@ -3,6 +3,7 @@ package hudson.plugins.performance.reports;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -320,7 +321,7 @@ public class ConstraintReport {
             }
         }
         try (FileOutputStream outWriter = new FileOutputStream(performanceLog, true)){
-            outWriter.write(getLoggerMsgAdv().getBytes());
+            outWriter.write(getLoggerMsgAdv().getBytes(StandardCharsets.UTF_8));
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/hudson/plugins/performance/reports/ConstraintReport.java
+++ b/src/main/java/hudson/plugins/performance/reports/ConstraintReport.java
@@ -311,7 +311,10 @@ public class ConstraintReport {
     public void writeResultsToFile() throws IOException {
         performanceLog = new File(newBuild.getRootDir() + File.separator + "performance-results" + File.separator + "performance.log");
         if (!performanceLog.exists()) {
-            performanceLog.getParentFile().mkdirs();
+            boolean dirsCreated = performanceLog.getParentFile().mkdirs();
+            if (!dirsCreated && !performanceLog.getParentFile().exists()) {
+                throw new IOException("Failed to create directory " + performanceLog.getParentFile());
+            }
             if (!performanceLog.createNewFile()) {
                 throw new IOException("Cannot create new file "+performanceLog.getAbsolutePath());
             }

--- a/src/main/java/hudson/plugins/performance/reports/PerformanceReport.java
+++ b/src/main/java/hudson/plugins/performance/reports/PerformanceReport.java
@@ -266,6 +266,11 @@ public class PerformanceReport extends AbstractReport implements Serializable,
         return getReportFileName() != null ? getReportFileName().equals(that.getReportFileName()) : that.getReportFileName() == null;
     }
 
+    @Override
+    public int hashCode() {
+        return getReportFileName() != null ? getReportFileName().hashCode() : 0;
+    }
+
     public int countErrors() {
         return nbError;
     }

--- a/src/main/java/hudson/plugins/performance/reports/PerformanceReport.java
+++ b/src/main/java/hudson/plugins/performance/reports/PerformanceReport.java
@@ -258,6 +258,14 @@ public class PerformanceReport extends AbstractReport implements Serializable,
         return getReportFileName().compareTo(jmReport.getReportFileName());
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        PerformanceReport that = (PerformanceReport) obj;
+        return getReportFileName() != null ? getReportFileName().equals(that.getReportFileName()) : that.getReportFileName() == null;
+    }
+
     public int countErrors() {
         return nbError;
     }

--- a/src/main/java/hudson/plugins/performance/reports/UriReport.java
+++ b/src/main/java/hudson/plugins/performance/reports/UriReport.java
@@ -209,6 +209,13 @@ public class UriReport extends AbstractReport implements Serializable, ModelObje
         }
         return uriReport.getUri().compareTo(this.getUri());
     }
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        UriReport uriReport = (UriReport) obj;
+        return getUri() != null ? getUri().equals(uriReport.getUri()) : uriReport.getUri() == null;
+    }
 
     public int countErrors() {
         return nbError;
@@ -617,6 +624,15 @@ public class UriReport extends AbstractReport implements Serializable, ModelObje
             if (this.date.before(other.date)) return -1;
             if (this.date.after(other.date)) return 1;
             return 0;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null || getClass() != obj.getClass()) return false;
+            Sample other = (Sample) obj;
+            if (duration != other.duration) return false;
+            return date != null ? date.equals(other.date) : other.date == null;
         }
     }
 

--- a/src/main/java/hudson/plugins/performance/reports/UriReport.java
+++ b/src/main/java/hudson/plugins/performance/reports/UriReport.java
@@ -217,6 +217,11 @@ public class UriReport extends AbstractReport implements Serializable, ModelObje
         return getUri() != null ? getUri().equals(uriReport.getUri()) : uriReport.getUri() == null;
     }
 
+    @Override
+    public int hashCode() {
+        return getUri() != null ? getUri().hashCode() : 0;
+    }
+
     public int countErrors() {
         return nbError;
     }

--- a/src/main/java/hudson/plugins/performance/reports/UriReport.java
+++ b/src/main/java/hudson/plugins/performance/reports/UriReport.java
@@ -634,6 +634,13 @@ public class UriReport extends AbstractReport implements Serializable, ModelObje
             if (duration != other.duration) return false;
             return date != null ? date.equals(other.date) : other.date == null;
         }
+
+        @Override
+        public int hashCode() {
+            int result = (int) (duration ^ (duration >>> 32));
+            result = 31 * result + (date != null ? date.hashCode() : 0);
+            return result;
+        }
     }
 
     @Deprecated


### PR DESCRIPTION
Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in early October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because we believe that the risk of a regression that only affects Java 11 is shallow. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

Testing done
===

Confirmed tests pass with Java 21 on Linux.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue