### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ node('linux-amd64') {
             sh 'pip install -r requirements.txt'
             
             def args = ['clean', 'install', '-Dset.changelist']
-            infra.runMaven(args, 11)
+            infra.runMaven(args, 21)
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <concurrency>2</concurrency>
         <!-- disable SpotBugs temporarily since there are 62 bugs -->
-        <spotbugs.failOnError>false</spotbugs.failOnError>
+        <spotbugs.skip>true</spotbugs.skip>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## Test with Java 21

Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only one Java configuration, Java 21 because the risk of a regression that only affects Java 11 is low. We generate Java 11 byte code with the Java 21 build, so we're already testing Java 11 byte code.

Skip spotbugs rather than ignoring.

### Testing done

Confirmed that tests pass with Java 21 on my Linux computer with virtualenv available.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
