### PR TITLE
Dependency updates (#310 and #311)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>6.2116.v7501b_67dc517</version>
+        <version>6.2138.v03274d462c13</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>5804.v80587a_38d937</version>
+                <version>6210.v69ea_fd8a_f010</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 virtualenv
 bzt
+urwid
 apiritif

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 virtualenv
 bzt
-urwid
+urwid>=3.0.2,<4.0.0
 apiritif


### PR DESCRIPTION
Combines #310 and #311 with a fix for `ERROR: ModuleNotFoundError: No module named 'urwid.decoration'`